### PR TITLE
Fix delete method query

### DIFF
--- a/DBAL/Crud.php
+++ b/DBAL/Crud.php
@@ -37,11 +37,11 @@ class Crud extends Query
 		$stm->execute($message->getValues());
 		return $stm->rowCount();
 	}
-	public function delete()
-	{
-		$message = $this->buildInsert($fields);
-		$stm = $this->connection->prepare($message->readMessage());
-		$stm->execute($message->getValues());
-		return $stm->rowCount();
-	}
+       public function delete()
+       {
+               $message = $this->buildDelete();
+               $stm = $this->connection->prepare($message->readMessage());
+               $stm->execute($message->getValues());
+               return $stm->rowCount();
+       }
 }


### PR DESCRIPTION
## Summary
- correct delete() method to build delete queries

## Testing
- `php -l DBAL/Crud.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866374c53c8832c87cad90aedb04fb5