### PR TITLE
Fix Query::from table node initialization

### DIFF
--- a/DBAL/QueryBuilder/Query.php
+++ b/DBAL/QueryBuilder/Query.php
@@ -25,11 +25,12 @@ class Query extends QueryNode
 	public function from(...$tables)
 	{
 		$clon = clone $this;
-		foreach ($tables as $table) {
-			if (!$table instanceof TableNode)
-				$_table = new TableNode($table);
-			$clon->getChild('tables')->appendChild($_table, $table);
-		}
+               foreach ($tables as $table) {
+                       $_table = ($table instanceof TableNode)
+                               ? $table
+                               : new TableNode($table);
+                       $clon->getChild('tables')->appendChild($_table);
+               }
 		return $clon;
 	}
 	protected function join($type, $table, array $on = [])


### PR DESCRIPTION
## Summary
- ensure `$table` is wrapped in a `TableNode` instance
- always append a `TableNode` instance to the tables node

## Testing
- `php -l DBAL/QueryBuilder/Query.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686637512a64832cad5a4bc85b7633c2