### PR TITLE
Fix JoinNode initialization and ON clause building

### DIFF
--- a/DBAL/QueryBuilder/Node/JoinNode.php
+++ b/DBAL/QueryBuilder/Node/JoinNode.php
@@ -2,6 +2,7 @@
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;
+use DBAL\QueryBuilder\Message;
 
 class JoinNode extends NotImplementedNode
 {
@@ -12,22 +13,24 @@ class JoinNode extends NotImplementedNode
 	protected $table;
 	protected $type;
 	protected $on = [];
-	public function __construct($table, $type = JoinNode::INNER_JOIN, array $on = [])
-	{
-		$this->table = $table;
-		$this->table = $type;
-		foreach ($on as $filter)
-			$this->on[] = new FilterNode($on);
-	}
-	public function send(MessageInterface $message)
-	{
-		$msg = new Message($message->type(), sprintf('%s %s', $this->type, $this->table));
-		if (sizeof($this->on) > 0) {
-			foreach ($this->on as $filter)
-				$msg = $filter->send($msg);
-		}
-		return $message->join($msg);
-	}
+        public function __construct($table, $type = JoinNode::INNER_JOIN, array $on = [])
+        {
+                $this->table = $table;
+                $this->type  = $type;
+                foreach ($on as $filter)
+                        $this->on[] = new FilterNode($filter);
+        }
+        public function send(MessageInterface $message)
+        {
+                $msg = new Message($message->type(), sprintf('%s %s', $this->type, $this->table));
+                if (sizeof($this->on) > 0) {
+                        $onMsg = new Message($message->type());
+                        foreach ($this->on as $filter)
+                                $onMsg = $filter->send($onMsg);
+                        $msg = $msg->join($onMsg->insertBefore('ON'));
+                }
+                return $message->join($msg);
+        }
 	public function __clone()
 	{
 		foreach ($this->on as $key=>$node)


### PR DESCRIPTION
## Summary
- store join type correctly
- build ON filters from each condition
- prepend `ON` keyword when join has conditions

## Testing
- `php -l DBAL/QueryBuilder/Node/JoinNode.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68663753fd60832c8bf2081ccb5089e3