### PR TITLE
Fix EmptyNode class name typo

### DIFF
--- a/DBAL/QueryBuilder/Node/EmptyNode.php
+++ b/DBAL/QueryBuilder/Node/EmptyNode.php
@@ -3,7 +3,7 @@ namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;
 
-class EmtyNode extends NotImplementedNode
+class EmptyNode extends NotImplementedNode
 {
 	protected $isEmpty = true;
 	public function send(MessageInterface $message)


### PR DESCRIPTION
## Summary
- fix typo in `EmptyNode` class name

## Testing
- `php -l DBAL/QueryBuilder/Node/EmptyNode.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866375771bc832c8463fbac13583585