### PR TITLE
Remove unused import

### DIFF
--- a/DBAL/QueryBuilder/Query.php
+++ b/DBAL/QueryBuilder/Query.php
@@ -1,7 +1,6 @@
 <?php
 namespace DBAL\QueryBuilder;
 
-use DBAL\Entity;
 use DBAL\ResultIterator;
 use DBAL\QueryBuilder\MessageInterface;
 use DBAL\QueryBuilder\Message;


### PR DESCRIPTION
## Summary
- delete stray `DBAL\Entity` import in `Query`

## Testing
- `php -l DBAL/QueryBuilder/Query.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866375a3074832c80cfcdfec891e1ba