### PR TITLE
Add dynamic filter builder to Query

### DIFF
--- a/DBAL/Crud.php
+++ b/DBAL/Crud.php
@@ -6,7 +6,7 @@ use DBAL\QueryBuilder\Query;
 class Crud extends Query
 {
 	protected $connection;
-	protected $mapers = [];
+	protected $mappers = [];
 	public function __construct(\PDO $connection)
 	{
 		$this->connection = $connection;
@@ -15,13 +15,13 @@ class Crud extends Query
 	public function map(callable $callback)
 	{
 		$clon = clone $this;
-		$clon->mapers[] = $callback;
+		$clon->mappers[] = $callback;
 		return $clon;
 	}
 	public function select(...$fields)
 	{
 		$message = $this->buildSelect(...$fields);
-		return new ResultIterator($this->connection, $message, $this->mapers);
+		return new ResultIterator($this->connection, $message, $this->mappers);
 	}
 	public function insert(array $fields)
 	{

--- a/DBAL/QueryBuilder/DynamicFilterBuilder.php
+++ b/DBAL/QueryBuilder/DynamicFilterBuilder.php
@@ -1,0 +1,18 @@
+<?php
+namespace DBAL\QueryBuilder;
+
+class DynamicFilterBuilder
+{
+       protected $filters = [];
+
+       public function __call($name, $arguments)
+       {
+               $this->filters[$name] = (count($arguments) <= 1) ? ($arguments[0] ?? null) : $arguments;
+               return $this;
+       }
+
+       public function toArray()
+       {
+               return $this->filters;
+       }
+}

--- a/DBAL/ResultIterator.php
+++ b/DBAL/ResultIterator.php
@@ -15,7 +15,7 @@ class ResultIterator implements \Iterator, \JsonSerializable
 	{
 		$this->pdo = $pdo;
 		$this->message = $message;
-		$this->mapers = $mappers;
+		$this->mappers = $mappers;
 	}
 	public function rewind()
 	{

--- a/DBAL/ResultIterator.php
+++ b/DBAL/ResultIterator.php
@@ -10,12 +10,12 @@ class ResultIterator implements \Iterator, \JsonSerializable
 	protected $result;
 	protected $i;
 	protected $stm;
-	protected $mapers;
-	public function __construct(\PDO $pdo, MessageInterface $message, array $mapers = [])
+	protected $mappers;
+	public function __construct(\PDO $pdo, MessageInterface $message, array $mappers = [])
 	{
 		$this->pdo = $pdo;
 		$this->message = $message;
-		$this->mapers = $mapers;
+		$this->mapers = $mappers;
 	}
 	public function rewind()
 	{
@@ -35,8 +35,8 @@ class ResultIterator implements \Iterator, \JsonSerializable
 	public function current()
 	{
 		$result = $this->result;
-		foreach ($this->mapers as $maper)
-			$result = call_user_func_array($maper, [$result]);
+		foreach ($this->mappers as $mapper)
+			$result = call_user_func_array($mapper, [$result]);
 		return $result;
 	}
 	public function next()

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # DBAL
 Simple dbal for php
+
+Example of dynamic filters:
+
+```php
+$crud->where(function ($q) {
+    $q->name__startWith('Al')->age__ge(21);
+});
+```
+


### PR DESCRIPTION
## Summary
- add `DynamicFilterBuilder` for collecting runtime filters
- allow `Query::where` to accept filter callbacks
- document dynamic usage in README
- adjust builder to return filters via `toArray` instead of `__invoke`

## Testing
- `php -l DBAL/QueryBuilder/DynamicFilterBuilder.php` *(fails: command not found)*
- `php -l DBAL/QueryBuilder/Query.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68663a0a7c88832cb0383888a56f1287