### PR TITLE
Fix duplicate SQL fragments in JoinsNode

### DIFF
--- a/DBAL/QueryBuilder/Node/JoinsNode.php
+++ b/DBAL/QueryBuilder/Node/JoinsNode.php
@@ -8,15 +8,14 @@ use DBAL\QueryBuilder\Node\NodeInterface;
 class JoinsNode extends Node
 {
 	protected $isEmpty = false;
-	public function send(MessageInterface $message)
-	{
-		$msg = new Message($message->type());
-		foreach ($this->allChildren() as $child) {
-			$_msg = $child->send($msg);
-			$msg = $msg->join($_msg);
-		}
-		return ($msg->getLength() > 0)? $message->join($msg) : $message;
-	}
+        public function send(MessageInterface $message)
+        {
+                $msg = new Message($message->type());
+                foreach ($this->allChildren() as $child) {
+                        $msg = $child->send($msg);
+                }
+                return ($msg->getLength() > 0) ? $message->join($msg) : $message;
+        }
 	public function appendChild(NodeInterface $node, $name = null)
 	{
 		if ($node instanceof JoinNode) {


### PR DESCRIPTION
## Summary
- ensure JoinsNode doesn't join the current fragment back into itself

## Testing
- `php -l DBAL/QueryBuilder/Node/JoinsNode.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68663e326634832ca30cdb2bef5c2c89