### PR TITLE
Add composer compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # DBAL
 Simple dbal for php
 
+## Installation
+
+Install via [Composer](https://getcomposer.org/):
+
+```bash
+composer require jorgesanabria/dbal
+```
+
 Example of dynamic filters:
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "jorgesanabria/dbal",
+    "description": "Simple DBAL for PHP",
+    "type": "library",
+    "license": "GPL-3.0-or-later",
+    "autoload": {
+        "psr-4": {
+            "DBAL\\": "DBAL/"
+        }
+    },
+    "require": {
+        "php": ">=7.0"
+    }
+}


### PR DESCRIPTION
## Summary
- add `composer.json` with PSR-4 autoload support
- document installation via Composer in README

## Testing
- `find DBAL -name '*.php' -print0 | xargs -0 -n1 php -l` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68663d44e6c4832cb86b49d1daa6da83