### PR TITLE
Add PHPUnit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,15 @@
             "DBAL\\": "DBAL/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "DBAL\\Tests\\": "tests/"
+        }
+    },
     "require": {
         "php": ">=7.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="dbal">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/CrudTest.php
+++ b/tests/CrudTest.php
@@ -1,0 +1,32 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\QueryBuilder\Query;
+
+class CrudTest extends TestCase
+{
+    private function createPdo()
+    {
+        return new PDO('sqlite::memory:');
+    }
+
+    public function testInsertSelectUpdateDelete()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+
+        $crud = (new Crud($pdo))->from('test');
+
+        $id = $crud->insert(['name' => 'Alice']);
+        $this->assertEquals(1, $id);
+
+        $row = iterator_to_array($crud->where(['id__eq' => $id])->select())[0];
+        $this->assertEquals('Alice', $row['name']);
+
+        $count = $crud->where(['id__eq' => $id])->update(['name' => 'Bob']);
+        $this->assertEquals(1, $count);
+
+        $count = $crud->where(['id__eq' => $id])->delete();
+        $this->assertEquals(1, $count);
+    }
+}

--- a/tests/DynamicFilterBuilderTest.php
+++ b/tests/DynamicFilterBuilderTest.php
@@ -1,0 +1,16 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\QueryBuilder\DynamicFilterBuilder;
+
+class DynamicFilterBuilderTest extends TestCase
+{
+    public function testMagicCallAndToArray()
+    {
+        $builder = new DynamicFilterBuilder();
+        $builder->name__eq('Alice')->age__ge(21);
+        $this->assertEquals([
+            'name__eq' => 'Alice',
+            'age__ge' => 21,
+        ], $builder->toArray());
+    }
+}

--- a/tests/FilterNodeTest.php
+++ b/tests/FilterNodeTest.php
@@ -1,0 +1,25 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\QueryBuilder\Message;
+use DBAL\QueryBuilder\MessageInterface;
+use DBAL\QueryBuilder\Node\FilterNode;
+
+class FilterNodeTest extends TestCase
+{
+    public function testFilterEq()
+    {
+        $node = new FilterNode(['name__eq' => 'Alice']);
+        $msg = $node->send(new Message());
+        $this->assertEquals('name = ?', $msg->readMessage());
+        $this->assertEquals(['Alice'], $msg->getValues());
+    }
+
+    public function testInWithSubquery()
+    {
+        $sub = new Message(MessageInterface::MESSAGE_TYPE_SELECT);
+        $sub = $sub->insertAfter('SELECT id FROM users');
+        $node = new FilterNode(['id__in' => $sub]);
+        $msg = $node->send(new Message());
+        $this->assertEquals('id in (SELECT id FROM users)', $msg->readMessage());
+    }
+}

--- a/tests/LimitNodeTest.php
+++ b/tests/LimitNodeTest.php
@@ -1,0 +1,26 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\QueryBuilder\Message;
+use DBAL\QueryBuilder\Node\LimitNode;
+
+class LimitNodeTest extends TestCase
+{
+    public function testLimitAndOffset()
+    {
+        $node = new LimitNode();
+        $node->setLimit(10);
+        $node->setOffset(5);
+        $msg = $node->send(new Message());
+        $this->assertEquals('LIMIT ? OFFSET ?', $msg->readMessage());
+        $this->assertEquals([10,5], $msg->getValues());
+    }
+
+    public function testOnlyLimit()
+    {
+        $node = new LimitNode();
+        $node->setLimit(3);
+        $msg = $node->send(new Message());
+        $this->assertEquals('LIMIT ?', $msg->readMessage());
+        $this->assertEquals([3], $msg->getValues());
+    }
+}

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -1,0 +1,27 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\QueryBuilder\Message;
+use DBAL\QueryBuilder\MessageInterface;
+
+class MessageTest extends TestCase
+{
+    public function testInsertBeforeAfterReplace()
+    {
+        $m = new Message(MessageInterface::MESSAGE_TYPE_SELECT, 'FROM foo');
+        $m = $m->insertBefore('SELECT *');
+        $m = $m->insertAfter('WHERE id = ?');
+        $m = $m->addValues([1]);
+        $this->assertEquals('SELECT * FROM foo WHERE id = ?', $m->readMessage());
+        $this->assertEquals([1], $m->getValues());
+        $this->assertSame(1, $m->numValues());
+        $this->assertSame(strlen('SELECT * FROM foo WHERE id = ?'), $m->getLength());
+    }
+
+    public function testJoinDifferentTypeThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $m1 = new Message(MessageInterface::MESSAGE_TYPE_SELECT, 'SELECT');
+        $m2 = new Message(MessageInterface::MESSAGE_TYPE_INSERT, 'INSERT');
+        $m1->join($m2);
+    }
+}

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1,0 +1,22 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\QueryBuilder\Query;
+use DBAL\QueryBuilder\Node\FieldNode;
+
+class QueryBuilderTest extends TestCase
+{
+    public function testBuildSelectWithFields()
+    {
+        $query = (new Query())->from('users');
+        $msg = $query->buildSelect('id', new FieldNode('name'));
+        $this->assertEquals('SELECT id, name FROM users', $msg->readMessage());
+    }
+
+    public function testWhereFilter()
+    {
+        $query = (new Query())->from('users')->where(['id__eq' => 1]);
+        $msg = $query->buildSelect();
+        $this->assertEquals('SELECT * FROM users WHERE id = ?', $msg->readMessage());
+        $this->assertEquals([1], $msg->getValues());
+    }
+}

--- a/tests/ResultIteratorTest.php
+++ b/tests/ResultIteratorTest.php
@@ -1,0 +1,36 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\QueryBuilder\Query;
+use DBAL\ResultIterator;
+
+class ResultIteratorTest extends TestCase
+{
+    private function pdoWithData()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $pdo->exec('INSERT INTO t(name) VALUES ("A"), ("B")');
+        return $pdo;
+    }
+
+    public function testIterator()
+    {
+        $pdo = $this->pdoWithData();
+        $query = (new Query())->from('t')->buildSelect('name');
+        $it = new ResultIterator($pdo, $query);
+        $names = [];
+        foreach ($it as $row) {
+            $names[] = $row['name'];
+        }
+        $this->assertEquals(['A','B'], $names);
+    }
+
+    public function testMapping()
+    {
+        $pdo = $this->pdoWithData();
+        $crud = (new Crud($pdo))->from('t')->map(function($row){ return $row['name']; });
+        $it = $crud->select('name');
+        $values = iterator_to_array($it);
+        $this->assertEquals(['A','B'], $values);
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit config and add dev dependencies for autoload
- write test coverage for QueryBuilder, Crud, ResultIterator, and others

## Testing
- `vendor/bin/phpunit --coverage-text` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6866549426d0832cbc4565974bd9a222