### PR TITLE
Add logical grouping to dynamic filter builder

### DIFF
--- a/DBAL/QueryBuilder/DynamicFilterBuilder.php
+++ b/DBAL/QueryBuilder/DynamicFilterBuilder.php
@@ -1,18 +1,82 @@
 <?php
 namespace DBAL\QueryBuilder;
 
+use DBAL\QueryBuilder\MessageInterface;
+use DBAL\QueryBuilder\Node\FilterNode;
+
 class DynamicFilterBuilder
 {
-       protected $filters = [];
+       protected $stack = [];
+       protected $nextOperator = MessageInterface::SEPARATOR_AND;
+
+       public function __construct()
+       {
+               $root = new FilterNode();
+               $this->stack[] = $root;
+       }
+
+       protected function current()
+       {
+               return $this->stack[count($this->stack) - 1];
+       }
 
        public function __call($name, $arguments)
        {
-               $this->filters[$name] = (count($arguments) <= 1) ? ($arguments[0] ?? null) : $arguments;
+               $node = new FilterNode([
+                       $name => (count($arguments) <= 1) ? ($arguments[0] ?? null) : $arguments
+               ], $this->nextOperator);
+               $this->nextOperator = MessageInterface::SEPARATOR_AND;
+               $this->current()->appendChild($node);
                return $this;
+       }
+
+       protected function group(callable $callback, $operator)
+       {
+               $node = new FilterNode([], $operator);
+               $this->nextOperator = MessageInterface::SEPARATOR_AND;
+               $this->current()->appendChild($node);
+               $this->stack[] = $node;
+               $callback($this);
+               array_pop($this->stack);
+               return $this;
+       }
+
+       public function andGroup(callable $callback)
+       {
+               return $this->group($callback, MessageInterface::SEPARATOR_AND);
+       }
+
+       public function orGroup(callable $callback)
+       {
+               return $this->group($callback, MessageInterface::SEPARATOR_OR);
+       }
+
+       public function andNext()
+       {
+               $this->nextOperator = MessageInterface::SEPARATOR_AND;
+               return $this;
+       }
+
+       public function orNext()
+       {
+               $this->nextOperator = MessageInterface::SEPARATOR_OR;
+               return $this;
+       }
+
+       public function toNode()
+       {
+               return $this->stack[0];
        }
 
        public function toArray()
        {
-               return $this->filters;
+               $parts = [];
+               foreach ($this->stack[0]->allChildren() as $child) {
+                       $childParts = $child->getParts();
+                       if (count($childParts) === 1 && count($child->allChildren()) === 0) {
+                               $parts += $childParts;
+                       }
+               }
+               return $parts;
        }
 }

--- a/DBAL/QueryBuilder/Query.php
+++ b/DBAL/QueryBuilder/Query.php
@@ -62,10 +62,13 @@ class Query extends QueryNode
                        if (is_callable($filter)) {
                                $builder = new DynamicFilterBuilder();
                                $filter($builder);
-                               $filter = $builder->toArray();
+                               $filter = $builder->toNode();
                        }
-                       if (is_array($filter))
+                       if ($filter instanceof FilterNode) {
+                               $clon->getChild('where')->appendChild($filter);
+                       } elseif (is_array($filter)) {
                                $clon->getChild('where')->appendChild(new FilterNode($filter));
+                       }
                }
                return $clon;
        }


### PR DESCRIPTION
## Summary
- extend `FilterNode` to support nested filter groups and operator customization
- add grouping and logical operator methods to `DynamicFilterBuilder`
- allow Query where() to accept built filter nodes
- test logical OR groups and precedence

## Testing
- `composer install` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686657a16218832cb430c990c6777660