### PR TITLE
Enable dynamic filters in join clauses

### DIFF
--- a/DBAL/QueryBuilder/Node/JoinNode.php
+++ b/DBAL/QueryBuilder/Node/JoinNode.php
@@ -17,8 +17,13 @@ class JoinNode extends NotImplementedNode
         {
                 $this->table = $table;
                 $this->type  = $type;
-                foreach ($on as $filter)
-                        $this->on[] = new FilterNode($filter);
+                foreach ($on as $filter) {
+                        if ($filter instanceof FilterNode) {
+                                $this->on[] = $filter;
+                        } else {
+                                $this->on[] = new FilterNode($filter);
+                        }
+                }
         }
         public function send(MessageInterface $message)
         {

--- a/DBAL/QueryBuilder/Query.php
+++ b/DBAL/QueryBuilder/Query.php
@@ -33,28 +33,40 @@ class Query extends QueryNode
                }
 		return $clon;
 	}
-	protected function join($type, $table, array $on = [])
-	{
-		$this->getChild('joins')->appendChild(new JoinNode($table, $type, $on));
-	}
-	public function innerJoin($table, array ...$on)
-	{
-		$clon = clone $this;
-		$clon->join(JoinNode::INNER_JOIN, $table, $on);
-		return $clon;
-	}
-	public function leftJoin($table, array ...$on)
-	{
-		$clon = clone $this;
-		$clon->join(JoinNode::LEFT_JOIN, $table, $on);
-		return $clon;
-	}
-	public function rightJoin($table, array ...$on)
-	{
-		$clon = clone $this;
-		$clon->join(JoinNode::RIGHT_JOIN, $table, $on);
-		return $clon;
-	}
+        protected function join($type, $table, array $on = [])
+        {
+                $conditions = [];
+                foreach ($on as $filter) {
+                        if (is_callable($filter)) {
+                                $builder = new DynamicFilterBuilder();
+                                $filter($builder);
+                                $conditions[] = $builder->toNode();
+                        } elseif ($filter instanceof FilterNode) {
+                                $conditions[] = $filter;
+                        } elseif (is_array($filter)) {
+                                $conditions[] = new FilterNode($filter);
+                        }
+                }
+                $this->getChild('joins')->appendChild(new JoinNode($table, $type, $conditions));
+        }
+        public function innerJoin($table, ...$on)
+        {
+                $clon = clone $this;
+                $clon->join(JoinNode::INNER_JOIN, $table, $on);
+                return $clon;
+        }
+        public function leftJoin($table, ...$on)
+        {
+                $clon = clone $this;
+                $clon->join(JoinNode::LEFT_JOIN, $table, $on);
+                return $clon;
+        }
+        public function rightJoin($table, ...$on)
+        {
+                $clon = clone $this;
+                $clon->join(JoinNode::RIGHT_JOIN, $table, $on);
+                return $clon;
+        }
        public function where(...$filters)
        {
                $clon = clone $this;

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ $crud->where(['id' => $id])->delete();
 ```php
 $resultado = $crud
     ->from('usuarios u')
-    ->leftJoin('perfiles p', ['u.id__eqf' => 'p.usuario_id'])
+    ->leftJoin('perfiles p', function ($on) {
+        $on->{'u.id__eqf'}('p.usuario_id');
+    })
     ->where(['p.activo__eq' => 1])
     ->select('u.id', 'p.foto');
 ```

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -43,4 +43,15 @@ class QueryBuilderTest extends TestCase
         $msg = $query->buildSelect();
         $this->assertEquals('SELECT * FROM users WHERE (name = ? OR name = ?) AND status = ?', $msg->readMessage());
     }
+
+    public function testJoinWithDynamicFilter()
+    {
+        $query = (new Query())
+            ->from('users u')
+            ->leftJoin('profiles p', function ($j) {
+                $j->{'u.id__eqf'}('p.user_id');
+            });
+        $msg = $query->buildSelect();
+        $this->assertEquals('SELECT * FROM users u LEFT JOIN profiles p ON u.id = p.user_id', $msg->readMessage());
+    }
 }


### PR DESCRIPTION
## Summary
- support `DynamicFilterBuilder` callbacks for join conditions
- relax join method signatures to accept mixed arguments
- allow `JoinNode` constructor to accept `FilterNode` instances directly
- document dynamic join filter syntax in README
- test join with dynamic filters

## Testing
- `vendor/bin/phpunit -c phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866599bb0e0832c9ab6b4f2e19824a9