### PR TITLE
Add middleware support for CRUD operations

### DIFF
--- a/DBAL/Crud.php
+++ b/DBAL/Crud.php
@@ -2,44 +2,60 @@
 namespace DBAL;
 
 use DBAL\QueryBuilder\Query;
+use DBAL\QueryBuilder\MessageInterface;
 
 class Crud extends Query
 {
-	protected $connection;
-	protected $mappers = [];
-	public function __construct(\PDO $connection)
-	{
-		$this->connection = $connection;
-		parent::__construct();
-	}
-	public function map(callable $callback)
-	{
-		$clon = clone $this;
-		$clon->mappers[] = $callback;
-		return $clon;
-	}
-	public function select(...$fields)
-	{
-		$message = $this->buildSelect(...$fields);
-		return new ResultIterator($this->connection, $message, $this->mappers);
-	}
-	public function insert(array $fields)
-	{
-		$message = $this->buildInsert($fields);
-		$stm = $this->connection->prepare($message->readMessage());
-		$stm->execute($message->getValues());
-		return $this->connection->lastInsertId();
-	}
-	public function update(array $fields)
-	{
-		$message = $this->buildUpdate($fields);
-		$stm = $this->connection->prepare($message->readMessage());
-		$stm->execute($message->getValues());
-		return $stm->rowCount();
-	}
+        protected $connection;
+        protected $mappers = [];
+        protected $middlewares = [];
+        public function __construct(\PDO $connection)
+        {
+                $this->connection = $connection;
+                parent::__construct();
+        }
+        public function map(callable $callback)
+        {
+                $clon = clone $this;
+                $clon->mappers[] = $callback;
+                return $clon;
+        }
+        public function withMiddleware(callable $mw)
+        {
+                $clon = clone $this;
+                $clon->middlewares[] = $mw;
+                return $clon;
+        }
+        protected function runMiddlewares(MessageInterface $message)
+        {
+                foreach ($this->middlewares as $mw)
+                        $mw($message);
+        }
+        public function select(...$fields)
+        {
+                $message = $this->buildSelect(...$fields);
+                return new ResultIterator($this->connection, $message, $this->mappers, $this->middlewares);
+        }
+        public function insert(array $fields)
+        {
+                $message = $this->buildInsert($fields);
+                $this->runMiddlewares($message);
+                $stm = $this->connection->prepare($message->readMessage());
+                $stm->execute($message->getValues());
+                return $this->connection->lastInsertId();
+        }
+        public function update(array $fields)
+        {
+                $message = $this->buildUpdate($fields);
+                $this->runMiddlewares($message);
+                $stm = $this->connection->prepare($message->readMessage());
+                $stm->execute($message->getValues());
+                return $stm->rowCount();
+        }
        public function delete()
        {
                $message = $this->buildDelete();
+               $this->runMiddlewares($message);
                $stm = $this->connection->prepare($message->readMessage());
                $stm->execute($message->getValues());
                return $stm->rowCount();

--- a/DBAL/MiddlewareInterface.php
+++ b/DBAL/MiddlewareInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+interface MiddlewareInterface
+{
+    public function __invoke(MessageInterface $message): void;
+}

--- a/DBAL/ResultIterator.php
+++ b/DBAL/ResultIterator.php
@@ -5,25 +5,29 @@ use DBAL\QueryBuilder\MessageInterface;
 
 class ResultIterator implements \Iterator, \JsonSerializable
 {
-	protected $pdo;
-	protected $message;
-	protected $result;
-	protected $i;
-	protected $stm;
-	protected $mappers;
-	public function __construct(\PDO $pdo, MessageInterface $message, array $mappers = [])
-	{
-		$this->pdo = $pdo;
-		$this->message = $message;
-		$this->mappers = $mappers;
-	}
-	public function rewind()
-	{
-		$this->stm = $this->pdo->prepare($this->message->readMessage());
-		$this->stm->execute($this->message->getValues());
-		$this->result = $this->stm->fetch();
-		$this->i = 0;
-	}
+        protected $pdo;
+        protected $message;
+        protected $result;
+        protected $i;
+        protected $stm;
+        protected $mappers;
+        protected $middlewares;
+        public function __construct(\PDO $pdo, MessageInterface $message, array $mappers = [], array $middlewares = [])
+        {
+                $this->pdo = $pdo;
+                $this->message = $message;
+                $this->mappers = $mappers;
+                $this->middlewares = $middlewares;
+        }
+        public function rewind()
+        {
+                foreach ($this->middlewares as $mw)
+                        $mw($this->message);
+                $this->stm = $this->pdo->prepare($this->message->readMessage());
+                $this->stm->execute($this->message->getValues());
+                $this->result = $this->stm->fetch();
+                $this->i = 0;
+        }
 	public function valid()
 	{
 		return $this->result !== false;

--- a/README.md
+++ b/README.md
@@ -117,3 +117,21 @@ foreach ($crudWithMapper->select() as $row) {
 }
 ```
 
+### Middlewares
+
+Middlewares allow you to intercept query execution for tasks like logging or
+validation.
+
+```php
+$crud = (new DBAL\Crud($pdo))
+    ->from('users')
+    ->withMiddleware(function (DBAL\QueryBuilder\MessageInterface $msg) {
+        error_log($msg->readMessage());
+    });
+
+$crud->insert(['name' => 'John']);
+```
+
+You can register multiple middlewares and they will run before the SQL statement
+is prepared and executed.
+

--- a/tests/CrudMiddlewareTest.php
+++ b/tests/CrudMiddlewareTest.php
@@ -1,0 +1,31 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+
+class CrudMiddlewareTest extends TestCase
+{
+    private function createPdo()
+    {
+        return new PDO('sqlite::memory:');
+    }
+
+    public function testMiddlewaresAreInvoked()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+
+        $count = 0;
+        $mw = function ($msg) use (&$count) {
+            $count++;
+        };
+
+        $crud = (new Crud($pdo))->from('test')->withMiddleware($mw);
+
+        $id = $crud->insert(['name' => 'A']);
+        iterator_to_array($crud->select());
+        $crud->where(['id__eq' => $id])->update(['name' => 'B']);
+        $crud->where(['id__eq' => $id])->delete();
+
+        $this->assertEquals(4, $count);
+    }
+}


### PR DESCRIPTION
## Summary
- add `MiddlewareInterface` to define middleware callbacks
- support registering middlewares in `Crud`
- execute middlewares before SQL execution in `Crud` and `ResultIterator`
- provide middleware unit test
- document middleware usage in README

## Testing
- `phpunit -c phpunit.xml` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_686686869c8c832c8aaa73c0319a437a