### PR TITLE
Update README with middleware class example

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ $crud = (new DBAL\Crud($pdo))
 $crud->insert(['name' => 'John']);
 ```
 
+Alternatively, you can create a class that implements
+`DBAL\MiddlewareInterface`:
+
+```php
+class MyMiddleware implements DBAL\MiddlewareInterface
+{
+    public function __invoke(DBAL\QueryBuilder\MessageInterface $msg): void
+    {
+        error_log($msg->readMessage());
+    }
+}
+
+$crud = $crud->withMiddleware(new MyMiddleware());
+```
+
 You can register multiple middlewares and they will run before the SQL statement
 is prepared and executed.
 


### PR DESCRIPTION
## Summary
- document how to implement a middleware class
- show registering it using `withMiddleware(new MyMiddleware())`

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668b6321c0832cbe146ad2a24fe375