### PR TITLE
Implement middleware method proxy

### DIFF
--- a/DBAL/Crud.php
+++ b/DBAL/Crud.php
@@ -60,4 +60,14 @@ class Crud extends Query
                $stm->execute($message->getValues());
                return $stm->rowCount();
        }
+
+       public function __call($name, $arguments)
+       {
+               foreach ($this->middlewares as $mw) {
+                       if (is_object($mw) && is_callable([$mw, $name])) {
+                               return $mw->$name(...$arguments);
+                       }
+               }
+               throw new \BadMethodCallException(sprintf('Method %s does not exist', $name));
+       }
 }

--- a/README.md
+++ b/README.md
@@ -135,3 +135,30 @@ $crud->insert(['name' => 'John']);
 You can register multiple middlewares and they will run before the SQL statement
 is prepared and executed.
 
+Middlewares can also be implemented as classes. Additional methods exposed by a
+middleware are accessible through the `Crud` instance thanks to `__call`:
+
+```php
+use DBAL\MiddlewareInterface;
+use DBAL\QueryBuilder\MessageInterface;
+
+class LoggerMiddleware implements MiddlewareInterface
+{
+    public function __invoke(MessageInterface $msg): void
+    {
+        error_log($msg->readMessage());
+    }
+
+    public function greet($name)
+    {
+        return "Hello {$name}";
+    }
+}
+
+$crud = (new DBAL\Crud($pdo))
+    ->from('users')
+    ->withMiddleware(new LoggerMiddleware());
+
+echo $crud->greet('John'); // "Hello John"
+```
+

--- a/tests/CrudMiddlewareMagicCallTest.php
+++ b/tests/CrudMiddlewareMagicCallTest.php
@@ -1,0 +1,30 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\QueryBuilder\MessageInterface;
+
+class CrudMiddlewareMagicCallTest extends TestCase
+{
+    private function createPdo()
+    {
+        return new PDO('sqlite::memory:');
+    }
+
+    public function testMiddlewareMethodsAreProxied()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+
+        $mw = new class {
+            public function __invoke(MessageInterface $msg): void {}
+            public function hello($name)
+            {
+                return "Hello $name";
+            }
+        };
+
+        $crud = (new Crud($pdo))->from('test')->withMiddleware($mw);
+
+        $this->assertEquals('Hello Bob', $crud->hello('Bob'));
+    }
+}


### PR DESCRIPTION
## Summary
- allow Crud to proxy dynamic method calls to middleware objects via `__call`
- show middleware class example in README
- test middleware method proxy in Crud

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686687b6bb3c832ca4694eec879f7367