### PR TITLE
Add entity validation middleware

### DIFF
--- a/DBAL/EntityValidationInterface.php
+++ b/DBAL/EntityValidationInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+interface EntityValidationInterface extends MiddlewareInterface
+{
+    public function beforeInsert(string $table, array $fields): void;
+    public function beforeUpdate(string $table, array $fields): void;
+}

--- a/DBAL/EntityValidationMiddleware.php
+++ b/DBAL/EntityValidationMiddleware.php
@@ -1,0 +1,136 @@
+<?php
+namespace DBAL;
+
+use InvalidArgumentException;
+use DBAL\QueryBuilder\MessageInterface;
+
+class EntityValidationMiddleware implements EntityValidationInterface
+{
+    private $rules = [];
+    private $relations = [];
+
+    private $currentTable;
+    private $currentField;
+
+    public function __invoke(MessageInterface $msg): void
+    {
+        // no-op
+    }
+
+    public function table(string $table): self
+    {
+        $this->currentTable = $table;
+        if (!isset($this->rules[$table])) {
+            $this->rules[$table] = [];
+        }
+        if (!isset($this->relations[$table])) {
+            $this->relations[$table] = [];
+        }
+        return $this;
+    }
+
+    public function field(string $field): self
+    {
+        $this->currentField = $field;
+        if (!isset($this->rules[$this->currentTable][$field])) {
+            $this->rules[$this->currentTable][$field] = [
+                'required' => false,
+                'validators' => []
+            ];
+        }
+        return $this;
+    }
+
+    public function relation(string $name, string $type, string $table, string $localKey, string $foreignKey): self
+    {
+        $this->relations[$this->currentTable][$name] = [
+            'type' => $type,
+            'table' => $table,
+            'localKey' => $localKey,
+            'foreignKey' => $foreignKey,
+        ];
+        return $this;
+    }
+
+    public function required(): self
+    {
+        $this->rules[$this->currentTable][$this->currentField]['required'] = true;
+        return $this;
+    }
+
+    public function string(): self
+    {
+        return $this->addValidator(function ($value) {
+            if (!is_string($value)) {
+                throw new InvalidArgumentException('Value must be a string');
+            }
+        });
+    }
+
+    public function integer(): self
+    {
+        return $this->addValidator(function ($value) {
+            if (!is_int($value)) {
+                throw new InvalidArgumentException('Value must be an integer');
+            }
+        });
+    }
+
+    public function maxLength(int $length): self
+    {
+        return $this->addValidator(function ($value) use ($length) {
+            if (is_string($value) && strlen($value) > $length) {
+                throw new InvalidArgumentException("Length must be <= {$length}");
+            }
+        });
+    }
+
+    public function email(): self
+    {
+        return $this->addValidator(function ($value) {
+            if (!is_string($value) || !filter_var($value, FILTER_VALIDATE_EMAIL)) {
+                throw new InvalidArgumentException('Invalid email');
+            }
+        });
+    }
+
+    private function addValidator(callable $validator): self
+    {
+        $this->rules[$this->currentTable][$this->currentField]['validators'][] = $validator;
+        return $this;
+    }
+
+    public function beforeInsert(string $table, array $fields): void
+    {
+        if (!isset($this->rules[$table])) {
+            return;
+        }
+        foreach ($this->rules[$table] as $field => $rule) {
+            if (!array_key_exists($field, $fields)) {
+                if ($rule['required']) {
+                    throw new InvalidArgumentException("Field {$field} is required");
+                }
+                continue;
+            }
+            $value = $fields[$field];
+            foreach ($rule['validators'] as $validator) {
+                $validator($value);
+            }
+        }
+    }
+
+    public function beforeUpdate(string $table, array $fields): void
+    {
+        if (!isset($this->rules[$table])) {
+            return;
+        }
+        foreach ($fields as $field => $value) {
+            if (!isset($this->rules[$table][$field])) {
+                continue;
+            }
+            foreach ($this->rules[$table][$field]['validators'] as $validator) {
+                $validator($value);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -177,3 +177,23 @@ $crud = (new DBAL\Crud($pdo))
 echo $crud->greet('John'); // "Hello John"
 ```
 
+### Entity validation middleware
+
+`EntityValidationMiddleware` provides a fluent API to validate data before it is
+inserted or updated. Validations are defined per table and field:
+
+```php
+$validation = (new DBAL\EntityValidationMiddleware())
+    ->table('users')
+        ->field('name')->required()->string()->maxLength(50)
+        ->field('email')->required()->email()
+    ->relation('profile', 'hasOne', 'profiles', 'id', 'user_id');
+
+$crud = (new DBAL\Crud($pdo))
+    ->from('users')
+    ->withMiddleware($validation);
+```
+
+An `InvalidArgumentException` is thrown when validations fail. Declared
+relations can be used by future lazy or eager loading features.
+

--- a/tests/EntityValidationMiddlewareTest.php
+++ b/tests/EntityValidationMiddlewareTest.php
@@ -1,0 +1,57 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\EntityValidationMiddleware;
+use DBAL\EntityValidationInterface;
+
+class EntityValidationMiddlewareTest extends TestCase
+{
+    private function createPdo()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, email TEXT)');
+        return $pdo;
+    }
+
+    private function createCrud(PDO $pdo)
+    {
+        $mw = (new EntityValidationMiddleware())
+            ->table('users')
+                ->field('name')->required()->string()->maxLength(50)
+                ->field('email')->required()->email();
+        return (new Crud($pdo))->from('users')->withMiddleware($mw);
+    }
+
+    public function testInsertInvalidDataThrows()
+    {
+        $crud = $this->createCrud($this->createPdo());
+        $this->expectException(InvalidArgumentException::class);
+        $crud->insert(['email' => 'foo@example.com']);
+    }
+
+    public function testInsertValidData()
+    {
+        $pdo = $this->createPdo();
+        $crud = $this->createCrud($pdo);
+        $id = $crud->insert(['name' => 'Alice', 'email' => 'alice@example.com']);
+        $this->assertEquals(1, $id);
+    }
+
+    public function testUpdateInvalidDataThrows()
+    {
+        $pdo = $this->createPdo();
+        $crud = $this->createCrud($pdo);
+        $id = $crud->insert(['name' => 'Bob', 'email' => 'bob@example.com']);
+        $this->expectException(InvalidArgumentException::class);
+        $crud->where(['id__eq' => $id])->update(['email' => 'not-an-email']);
+    }
+
+    public function testUpdateValidData()
+    {
+        $pdo = $this->createPdo();
+        $crud = $this->createCrud($pdo);
+        $id = $crud->insert(['name' => 'Carol', 'email' => 'carol@example.com']);
+        $count = $crud->where(['id__eq' => $id])->update(['name' => 'Caro']);
+        $this->assertEquals(1, $count);
+    }
+}


### PR DESCRIPTION
## Summary
- add `EntityValidationInterface` and implementation
- support validation middleware in `Crud`
- add tests for the new middleware
- document entity validation middleware usage

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686698f7f508832c91a4049c4db98e69