### PR TITLE
Fix duplicate getRelations method

### DIFF
--- a/DBAL/EntityValidationMiddleware.php
+++ b/DBAL/EntityValidationMiddleware.php
@@ -54,11 +54,6 @@ class EntityValidationMiddleware implements EntityValidationInterface
         return $this->relations[$table] ?? [];
     }
 
-    public function getRelations(string $table): array
-    {
-        return $this->relations[$table] ?? [];
-    }
-
     public function required(): self
     {
         $this->rules[$this->currentTable][$this->currentField]['required'] = true;


### PR DESCRIPTION
## Summary
- remove the duplicated `getRelations` method in `EntityValidationMiddleware`

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6866b5829574832c8b921d687e84e3b1