### PR TITLE
Implement relation shortcut

### DIFF
--- a/DBAL/EntityValidationMiddleware.php
+++ b/DBAL/EntityValidationMiddleware.php
@@ -42,10 +42,37 @@ class EntityValidationMiddleware implements EntityValidationInterface
         return $this;
     }
 
-    public function relation(string $name): RelationDefinition
-    {
+    public function relation(
+        string $name,
+        string $type = null,
+        string $table = null,
+        string $localKey = null,
+        string $foreignKey = null
+    ): RelationDefinition {
         $relation = new RelationDefinition($name);
         $this->relations[$this->currentTable][$name] = $relation;
+
+        if ($type !== null && $table !== null && $localKey !== null && $foreignKey !== null) {
+            switch ($type) {
+                case 'hasOne':
+                    $relation->hasOne($table);
+                    break;
+                case 'hasMany':
+                    $relation->hasMany($table);
+                    break;
+                case 'belongsTo':
+                    $relation->belongsTo($table);
+                    break;
+                default:
+                    throw new InvalidArgumentException('Invalid relation type');
+            }
+            $relation->on(
+                "{$this->currentTable}.{$localKey}",
+                '=',
+                "{$table}.{$foreignKey}"
+            );
+        }
+
         return $relation;
     }
 

--- a/DBAL/RelationDefinition.php
+++ b/DBAL/RelationDefinition.php
@@ -27,6 +27,13 @@ class RelationDefinition
         return $this;
     }
 
+    public function belongsTo(string $table): self
+    {
+        $this->type = 'belongsTo';
+        $this->table = $table;
+        return $this;
+    }
+
     public function on(string $left, string $operator, string $right): self
     {
         $this->conditions[] = [$left, $operator, $right];

--- a/tests/EntityValidationMiddlewareTest.php
+++ b/tests/EntityValidationMiddlewareTest.php
@@ -68,4 +68,19 @@ class EntityValidationMiddlewareTest extends TestCase
         $this->assertArrayHasKey('profile', $rels);
         $this->assertInstanceOf(DBAL\RelationDefinition::class, $rels['profile']);
     }
+
+    public function testRelationShortcut()
+    {
+        $mw = (new EntityValidationMiddleware())
+            ->table('users')
+                ->relation('profile', 'hasOne', 'profiles', 'id', 'user_id');
+
+        $rel = $mw->getRelation('users', 'profile');
+        $this->assertInstanceOf(RelationDefinition::class, $rel);
+        $this->assertEquals('hasOne', $rel->getType());
+        $this->assertEquals('profiles', $rel->getTable());
+        $this->assertEquals([
+            ['users.id', '=', 'profiles.user_id']
+        ], $rel->getConditions());
+    }
 }


### PR DESCRIPTION
## Summary
- allow `EntityValidationMiddleware::relation()` to take optional parameters
- support new `belongsTo` relation type
- test relation shortcut usage

## Testing
- `phpunit --version` *(fails: command not found)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b5864c28832c89f08e1b3b36717d