### PR TITLE
Add ActiveRecord middleware and records

### DIFF
--- a/DBAL/ActiveRecord.php
+++ b/DBAL/ActiveRecord.php
@@ -1,0 +1,74 @@
+<?php
+namespace DBAL;
+
+class ActiveRecord implements \JsonSerializable
+{
+        private $crud;
+        private $original = [];
+        private $modified = [];
+
+        public function __construct(Crud $crud, array $data)
+        {
+                $this->crud = $crud;
+                $this->original = $data;
+        }
+
+        public function __call($name, $arguments)
+        {
+                if (strpos($name, 'get__') === 0) {
+                        $field = substr($name, 5);
+                        return array_key_exists($field, $this->modified)
+                                ? $this->modified[$field]
+                                : ($this->original[$field] ?? null);
+                }
+                if (strpos($name, 'set__') === 0) {
+                        $field = substr($name, 5);
+                        $this->modified[$field] = $arguments[0] ?? null;
+                        return $this;
+                }
+                throw new \BadMethodCallException(sprintf('Method %s does not exist', $name));
+        }
+
+        public function __get($name)
+        {
+                return array_key_exists($name, $this->modified)
+                        ? $this->modified[$name]
+                        : ($this->original[$name] ?? null);
+        }
+
+        public function __set($name, $value)
+        {
+                $this->modified[$name] = $value;
+        }
+
+        public function update()
+        {
+                if (!array_key_exists('id', $this->original)) {
+                        throw new \RuntimeException('id field missing');
+                }
+                $changed = [];
+                foreach ($this->modified as $field => $value) {
+                        if (!array_key_exists($field, $this->original) || $this->original[$field] !== $value) {
+                                $changed[$field] = $value;
+                        }
+                }
+                if (empty($changed)) {
+                        return 0;
+                }
+                $count = $this->crud
+                        ->where(['id__eq' => $this->original['id']])
+                        ->update($changed);
+                $this->original = array_merge($this->original, $changed);
+                $this->modified = [];
+                return $count;
+        }
+
+        public function jsonSerialize()
+        {
+                $data = $this->original;
+                foreach ($this->modified as $k => $v) {
+                        $data[$k] = $v;
+                }
+                return $data;
+        }
+}

--- a/DBAL/ActiveRecordMiddleware.php
+++ b/DBAL/ActiveRecordMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+class ActiveRecordMiddleware implements MiddlewareInterface
+{
+        public function __invoke(MessageInterface $msg): void
+        {
+                // no-op
+        }
+
+        public function attach(Crud $crud): Crud
+        {
+                $ref = null;
+                $crud = $crud->map(function(array $row) use (&$ref) {
+                        return new ActiveRecord($ref, $row);
+                });
+                $crud = $crud->withMiddleware($this);
+                $ref = $crud;
+                return $crud;
+        }
+}

--- a/tests/ActiveRecordMiddlewareTest.php
+++ b/tests/ActiveRecordMiddlewareTest.php
@@ -1,0 +1,58 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\ActiveRecordMiddleware;
+use DBAL\ActiveRecord;
+use DBAL\QueryBuilder\MessageInterface;
+
+class ActiveRecordMiddlewareTest extends TestCase
+{
+    private function createPdo()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, email TEXT)');
+        $pdo->exec('INSERT INTO users(name,email) VALUES ("Alice","alice@example.com")');
+        return $pdo;
+    }
+
+    public function testDynamicGettersAndSetters()
+    {
+        $pdo = $this->createPdo();
+        $crud = (new Crud($pdo))->from('users');
+        $mw = new ActiveRecordMiddleware();
+        $crud = $mw->attach($crud);
+
+        $rows = iterator_to_array($crud->select());
+        $record = $rows[0];
+
+        $this->assertInstanceOf(ActiveRecord::class, $record);
+        $this->assertEquals('Alice', $record->get__name());
+        $record->set__name('Bob');
+        $this->assertEquals('Bob', $record->get__name());
+    }
+
+    public function testUpdateOnlyChangedFieldsAreSent()
+    {
+        $pdo = $this->createPdo();
+        $log = [];
+        $logger = function (MessageInterface $m) use (&$log) {
+            if ($m->type() === MessageInterface::MESSAGE_TYPE_UPDATE) {
+                $log[] = [$m->readMessage(), $m->getValues()];
+            }
+        };
+
+        $crud = (new Crud($pdo))->from('users')->withMiddleware($logger);
+        $mw = new ActiveRecordMiddleware();
+        $crud = $mw->attach($crud);
+
+        $record = iterator_to_array($crud->where(['id__eq' => 1])->select())[0];
+        $record->set__name('Alice2');
+        $record->set__email('alice@example.com');
+        $record->update();
+
+        $this->assertCount(1, $log);
+        $this->assertStringContainsString('SET name = ?', $log[0][0]);
+        $this->assertStringNotContainsString('email', $log[0][0]);
+        $this->assertEquals(['Alice2', 1], $log[0][1]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ActiveRecord` entity class
- add `ActiveRecordMiddleware` for mapping results to ActiveRecord
- support dynamic getters/setters and updates
- test ActiveRecord functionality

## Testing
- `./vendor/bin/phpunit -c phpunit.xml tests/ActiveRecordMiddlewareTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6866b8da7ef8832cbb639d0fa6ab1fda