### PR TITLE
Add caching middleware

### DIFF
--- a/DBAL/CacheMiddleware.php
+++ b/DBAL/CacheMiddleware.php
@@ -1,0 +1,47 @@
+<?php
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+class CacheMiddleware implements MiddlewareInterface
+{
+    private $storage;
+
+    public function __construct(CacheStorageInterface $storage = null)
+    {
+        $this->storage = $storage ?: new MemoryCacheStorage();
+    }
+
+    public function __invoke(MessageInterface $msg): void
+    {
+        if (in_array($msg->type(), [
+            MessageInterface::MESSAGE_TYPE_INSERT,
+            MessageInterface::MESSAGE_TYPE_UPDATE,
+            MessageInterface::MESSAGE_TYPE_DELETE,
+        ])) {
+            // Invalidate entire cache on data changes
+            $this->storage->delete();
+        }
+    }
+
+    private function key(MessageInterface $msg): string
+    {
+        return sha1($msg->readMessage() . '|' . serialize($msg->getValues()));
+    }
+
+    public function fetch(MessageInterface $msg)
+    {
+        if ($msg->type() !== MessageInterface::MESSAGE_TYPE_SELECT) {
+            return null;
+        }
+        return $this->storage->get($this->key($msg));
+    }
+
+    public function save(MessageInterface $msg, array $rows): void
+    {
+        if ($msg->type() !== MessageInterface::MESSAGE_TYPE_SELECT) {
+            return;
+        }
+        $this->storage->set($this->key($msg), $rows);
+    }
+}

--- a/DBAL/CacheStorageInterface.php
+++ b/DBAL/CacheStorageInterface.php
@@ -1,0 +1,12 @@
+<?php
+namespace DBAL;
+
+interface CacheStorageInterface
+{
+    public function get(string $key);
+    public function set(string $key, $value): void;
+    /**
+     * Delete a cached value. If $key is null, all entries MUST be removed.
+     */
+    public function delete(string $key = null): void;
+}

--- a/DBAL/MemoryCacheStorage.php
+++ b/DBAL/MemoryCacheStorage.php
@@ -1,0 +1,26 @@
+<?php
+namespace DBAL;
+
+class MemoryCacheStorage implements CacheStorageInterface
+{
+    private $data = [];
+
+    public function get(string $key)
+    {
+        return $this->data[$key] ?? null;
+    }
+
+    public function set(string $key, $value): void
+    {
+        $this->data[$key] = $value;
+    }
+
+    public function delete(string $key = null): void
+    {
+        if ($key === null) {
+            $this->data = [];
+        } else {
+            unset($this->data[$key]);
+        }
+    }
+}

--- a/DBAL/SqliteCacheStorage.php
+++ b/DBAL/SqliteCacheStorage.php
@@ -1,0 +1,40 @@
+<?php
+namespace DBAL;
+
+use PDO;
+
+class SqliteCacheStorage implements CacheStorageInterface
+{
+    private $pdo;
+
+    public function __construct(string $file)
+    {
+        $this->pdo = new PDO('sqlite:' . $file);
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('CREATE TABLE IF NOT EXISTS cache (key TEXT PRIMARY KEY, value BLOB)');
+    }
+
+    public function get(string $key)
+    {
+        $stmt = $this->pdo->prepare('SELECT value FROM cache WHERE key = ?');
+        $stmt->execute([$key]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ? unserialize($row['value']) : null;
+    }
+
+    public function set(string $key, $value): void
+    {
+        $stmt = $this->pdo->prepare('REPLACE INTO cache(key, value) VALUES(?, ?)');
+        $stmt->execute([$key, serialize($value)]);
+    }
+
+    public function delete(string $key = null): void
+    {
+        if ($key === null) {
+            $this->pdo->exec('DELETE FROM cache');
+        } else {
+            $stmt = $this->pdo->prepare('DELETE FROM cache WHERE key = ?');
+            $stmt->execute([$key]);
+        }
+    }
+}

--- a/tests/CacheMiddlewareTest.php
+++ b/tests/CacheMiddlewareTest.php
@@ -1,0 +1,91 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\CacheMiddleware;
+use DBAL\SqliteCacheStorage;
+use DBAL\CacheStorageInterface;
+
+class CacheMiddlewareTest extends TestCase
+{
+    private function createPdo()
+    {
+        return new PDO('sqlite::memory:');
+    }
+
+    public function testMemoryCache()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $pdo->exec('INSERT INTO test(name) VALUES ("A")');
+
+        $cache = new CacheMiddleware();
+        $crud = (new Crud($pdo))->from('test')->withMiddleware($cache);
+
+        $rows = iterator_to_array($crud->select());
+        $this->assertEquals('A', $rows[0]['name']);
+
+        // Modify DB directly, cache should still return old result
+        $pdo->exec('DELETE FROM test');
+        $rows = iterator_to_array($crud->select());
+        $this->assertEquals('A', $rows[0]['name']);
+
+        // Insert via Crud to invalidate cache
+        $crud->insert(['name' => 'B']);
+        $rows = iterator_to_array($crud->select());
+        $this->assertEquals('B', $rows[0]['name']);
+    }
+
+    public function testSqliteCache()
+    {
+        $file = tempnam(sys_get_temp_dir(), 'cache');
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $pdo->exec('INSERT INTO test(name) VALUES ("A")');
+
+        $storage = new SqliteCacheStorage($file);
+        $cache = new CacheMiddleware($storage);
+        $crud = (new Crud($pdo))->from('test')->withMiddleware($cache);
+
+        $rows = iterator_to_array($crud->select());
+        $this->assertEquals('A', $rows[0]['name']);
+        $pdo->exec('DELETE FROM test');
+        $rows = iterator_to_array($crud->select());
+        $this->assertEquals('A', $rows[0]['name']);
+
+        $crud->insert(['name' => 'B']);
+        $rows = iterator_to_array($crud->select());
+        $this->assertEquals('B', $rows[0]['name']);
+        unlink($file);
+    }
+
+    public function testCustomStorageIsUsed()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $pdo->exec('INSERT INTO test(name) VALUES ("A")');
+
+        $storage = new class implements CacheStorageInterface {
+            public $gets = 0;
+            public $sets = 0;
+            public $deletes = 0;
+            private $data = [];
+            public function get(string $key) { $this->gets++; return $this->data[$key] ?? null; }
+            public function set(string $key, $value): void { $this->sets++; $this->data[$key] = $value; }
+            public function delete(string $key = null): void { $this->deletes++; if ($key === null) { $this->data = []; } else { unset($this->data[$key]); } }
+        };
+
+        $cache = new CacheMiddleware($storage);
+        $crud = (new Crud($pdo))->from('test')->withMiddleware($cache);
+
+        iterator_to_array($crud->select());
+        $this->assertEquals(1, $storage->gets);
+        $this->assertEquals(1, $storage->sets);
+
+        iterator_to_array($crud->select());
+        $this->assertEquals(2, $storage->gets);
+        $this->assertEquals(1, $storage->sets);
+
+        $crud->insert(['name' => 'B']);
+        $this->assertEquals(1, $storage->deletes);
+    }
+}

--- a/vendor/autoload.php
+++ b/vendor/autoload.php
@@ -1,0 +1,14 @@
+<?php
+spl_autoload_register(function ($class) {
+    $prefix = 'DBAL\\';
+    $base_dir = __DIR__ . '/../DBAL/';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+    $relative = substr($class, $len);
+    $file = $base_dir . str_replace('\\', '/', $relative) . '.php';
+    if (file_exists($file)) {
+        require $file;
+    }
+});


### PR DESCRIPTION
## Summary
- implement caching middleware and storage layer
- support memory and SQLite cache implementations
- allow custom cache storage injection
- integrate caching with ResultIterator
- add unit tests for cache middleware
- add simple PSR-4 autoloader for tests

## Testing
- `phpunit -c phpunit.xml` *(fails: `phpunit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6866b8e3c510832c8bcbd0a340d60320