### PR TITLE
Remove leftover shell prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,4 +227,3 @@ $user = iterator_to_array($crud->where(['id' => 1])->select())[0];
 $profile = $user['profile'];
 echo $profile['photo'];
 ```
-


### PR DESCRIPTION
## Summary
- clean up README formatting by removing stray shell prompt line

## Testing
- `phpunit --version` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6866b8e698bc832cb6a840871b746501