### PR TITLE
Add FirstLastMiddleware helper

### DIFF
--- a/DBAL/FirstLastMiddleware.php
+++ b/DBAL/FirstLastMiddleware.php
@@ -1,0 +1,57 @@
+<?php
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+class FirstLastMiddleware implements MiddlewareInterface
+{
+    private $crud;
+
+    public function __invoke(MessageInterface $msg): void
+    {
+        // no-op
+    }
+
+    public function attach(Crud $crud): Crud
+    {
+        $crud = $crud->withMiddleware($this);
+        $this->crud = $crud;
+        return $crud;
+    }
+
+    public function first(...$fields)
+    {
+        $rows = iterator_to_array($this->crud->limit(1)->select(...$fields));
+        if (!isset($rows[0])) {
+            throw new \RuntimeException('No record found');
+        }
+        return $rows[0];
+    }
+
+    public function firstOrDefault($default = null, ...$fields)
+    {
+        $rows = iterator_to_array($this->crud->limit(1)->select(...$fields));
+        if (!isset($rows[0])) {
+            return is_callable($default) ? $default() : $default;
+        }
+        return $rows[0];
+    }
+
+    public function last(...$fields)
+    {
+        $rows = iterator_to_array($this->crud->select(...$fields));
+        if (empty($rows)) {
+            throw new \RuntimeException('No record found');
+        }
+        return $rows[count($rows) - 1];
+    }
+
+    public function lastOrDefault($default = null, ...$fields)
+    {
+        $rows = iterator_to_array($this->crud->select(...$fields));
+        if (empty($rows)) {
+            return is_callable($default) ? $default() : $default;
+        }
+        return $rows[count($rows) - 1];
+    }
+}

--- a/README.md
+++ b/README.md
@@ -177,6 +177,22 @@ $crud = (new DBAL\Crud($pdo))
 echo $crud->greet('John'); // "Hello John"
 ```
 
+### First/Last middleware
+
+`FirstLastMiddleware` provides helper methods to retrieve the first or last row of a query.
+
+```php
+$fl = new DBAL\FirstLastMiddleware();
+$crud = (new DBAL\Crud($pdo))
+    ->from('users');
+$crud = $fl->attach($crud);
+
+$user = $crud->first();
+$lastUser = $crud->last('id', 'name');
+```
+
+`first()` and `last()` throw a `RuntimeException` when no rows exist. `firstOrDefault()` and `lastOrDefault()` allow providing a default value.
+
 ### Entity validation middleware
 
 `EntityValidationMiddleware` provides a fluent API to validate data before it is

--- a/tests/FirstLastMiddlewareTest.php
+++ b/tests/FirstLastMiddlewareTest.php
@@ -1,0 +1,83 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\FirstLastMiddleware;
+
+class FirstLastMiddlewareTest extends TestCase
+{
+    private function createPdo()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        return $pdo;
+    }
+
+    private function withData(PDO $pdo)
+    {
+        $pdo->exec('INSERT INTO items(name) VALUES ("A"), ("B"), ("C")');
+    }
+
+    public function testFirstRowIsReturned()
+    {
+        $pdo = $this->createPdo();
+        $this->withData($pdo);
+        $mw = new FirstLastMiddleware();
+        $crud = (new Crud($pdo))->from('items');
+        $crud = $mw->attach($crud);
+
+        $row = $crud->first('name');
+        $this->assertEquals('A', $row['name']);
+    }
+
+    public function testFirstThrowsWhenEmpty()
+    {
+        $pdo = $this->createPdo();
+        $mw = new FirstLastMiddleware();
+        $crud = $mw->attach((new Crud($pdo))->from('items'));
+        $this->expectException(RuntimeException::class);
+        $crud->first();
+    }
+
+    public function testFirstOrDefaultReturnsProvidedDefault()
+    {
+        $pdo = $this->createPdo();
+        $mw = new FirstLastMiddleware();
+        $crud = $mw->attach((new Crud($pdo))->from('items'));
+
+        $value = $crud->firstOrDefault('default');
+        $this->assertEquals('default', $value);
+
+        $call = $crud->firstOrDefault(function(){ return 'callable'; });
+        $this->assertEquals('callable', $call);
+    }
+
+    public function testLastRowIsReturned()
+    {
+        $pdo = $this->createPdo();
+        $this->withData($pdo);
+        $mw = new FirstLastMiddleware();
+        $crud = $mw->attach((new Crud($pdo))->from('items'));
+
+        $row = $crud->last('name');
+        $this->assertEquals('C', $row['name']);
+    }
+
+    public function testLastThrowsWhenEmpty()
+    {
+        $pdo = $this->createPdo();
+        $mw = new FirstLastMiddleware();
+        $crud = $mw->attach((new Crud($pdo))->from('items'));
+        $this->expectException(RuntimeException::class);
+        $crud->last();
+    }
+
+    public function testLastOrDefaultReturnsDefault()
+    {
+        $pdo = $this->createPdo();
+        $mw = new FirstLastMiddleware();
+        $crud = $mw->attach((new Crud($pdo))->from('items'));
+
+        $value = $crud->lastOrDefault('d');
+        $this->assertEquals('d', $value);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `FirstLastMiddleware` to fetch the first or last row from `Crud`
- add PHPUnit tests for new middleware
- document how to attach and use the middleware in the README

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866be1675b8832ca92d088b552fa2f4