### PR TITLE
Add Linq middleware with CRUD awareness

### DIFF
--- a/DBAL/Crud.php
+++ b/DBAL/Crud.php
@@ -140,6 +140,9 @@ class Crud extends Query
        {
                foreach ($this->middlewares as $mw) {
                        if (is_object($mw) && is_callable([$mw, $name])) {
+                               if ($mw instanceof CrudAwareMiddlewareInterface) {
+                                       array_unshift($arguments, $this);
+                               }
                                return $mw->$name(...$arguments);
                        }
                }

--- a/DBAL/CrudAwareMiddlewareInterface.php
+++ b/DBAL/CrudAwareMiddlewareInterface.php
@@ -1,0 +1,6 @@
+<?php
+namespace DBAL;
+
+interface CrudAwareMiddlewareInterface extends MiddlewareInterface
+{
+}

--- a/DBAL/LinqMiddleware.php
+++ b/DBAL/LinqMiddleware.php
@@ -1,0 +1,44 @@
+<?php
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+class LinqMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterface
+{
+    public function __invoke(MessageInterface $msg): void
+    {
+        // no-op
+    }
+
+    private function countRows(Crud $crud): int
+    {
+        $rows = iterator_to_array($crud->select('COUNT(*) AS c'));
+        return (int)($rows[0]['c'] ?? 0);
+    }
+
+    public function any(Crud $crud, ...$filters): bool
+    {
+        $rows = iterator_to_array($crud->where(...$filters)->limit(1)->select('1'));
+        return !empty($rows);
+    }
+
+    public function none(Crud $crud, ...$filters): bool
+    {
+        return !$this->any($crud, ...$filters);
+    }
+
+    public function all(Crud $crud, ...$filters): bool
+    {
+        $total = $this->countRows($crud);
+        if ($total === 0) {
+            return true;
+        }
+        $matched = $this->countRows($crud->where(...$filters));
+        return $total === $matched;
+    }
+
+    public function notAll(Crud $crud, ...$filters): bool
+    {
+        return !$this->all($crud, ...$filters);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -193,6 +193,20 @@ $lastUser = $crud->last('id', 'name');
 
 `first()` and `last()` throw a `RuntimeException` when no rows exist. `firstOrDefault()` and `lastOrDefault()` allow providing a default value.
 
+### Linq middleware
+
+`LinqMiddleware` exposes helper methods to query for the existence of records.
+
+```php
+$linq = new DBAL\LinqMiddleware();
+$crud = (new DBAL\Crud($pdo))
+    ->from('users')
+    ->withMiddleware($linq);
+
+$hasInactive = $crud->any(['active__eq' => 0]);
+$allActive = $crud->all(['active__eq' => 1]);
+```
+
 ### Entity validation middleware
 
 `EntityValidationMiddleware` provides a fluent API to validate data before it is

--- a/tests/LinqMiddlewareTest.php
+++ b/tests/LinqMiddlewareTest.php
@@ -1,0 +1,51 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\LinqMiddleware;
+
+class LinqMiddlewareTest extends TestCase
+{
+    private function createPdo()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, active INTEGER)');
+        $pdo->exec('INSERT INTO items(name, active) VALUES ("A", 1), ("B", 1), ("C", 0)');
+        return $pdo;
+    }
+
+    private function createCrud(PDO $pdo)
+    {
+        $mw = new LinqMiddleware();
+        return (new Crud($pdo))->from('items')->withMiddleware($mw);
+    }
+
+    public function testAnyNoneWithFilters()
+    {
+        $crud = $this->createCrud($this->createPdo());
+
+        $this->assertTrue($crud->any(['name__eq' => 'A']));
+        $this->assertFalse($crud->any(['name__eq' => 'Z']));
+        $this->assertTrue($crud->none(['name__eq' => 'Z']));
+
+        $any = $crud->any(function ($f) { $f->name__eq('B'); });
+        $this->assertTrue($any);
+    }
+
+    public function testAllAndNotAll()
+    {
+        $crud = $this->createCrud($this->createPdo());
+
+        $this->assertFalse($crud->all(['active__eq' => 1]));
+        $this->assertTrue($crud->notAll(['active__eq' => 1]));
+
+        $subset = $crud->where(['active__eq' => 1]);
+        $this->assertTrue($subset->all(['active__eq' => 1]));
+    }
+
+    public function testChainedWhereIsPreserved()
+    {
+        $crud = $this->createCrud($this->createPdo());
+
+        $this->assertFalse($crud->where(['id__eq' => 999])->any());
+    }
+}


### PR DESCRIPTION
## Summary
- add CrudAwareMiddlewareInterface for middleware methods expecting a Crud instance
- update Crud::__call to pass $this to Crud-aware middlewares
- implement LinqMiddleware providing any/none/all/notAll helpers
- document the Linq middleware in README
- add tests for LinqMiddleware

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c0474ad4832c818f838e47f22958