### PR TITLE
Add groupBy alias and tests

### DIFF
--- a/DBAL/QueryBuilder/Query.php
+++ b/DBAL/QueryBuilder/Query.php
@@ -91,18 +91,23 @@ class Query extends QueryNode
 			$clon->getChild('having')->appendChild(new FilterNode($filter));
 		return $clon;
 	}
-	public function group(...$fields)
-	{
-		$clon = clone $this;
-		foreach ($fields as $field)
-			$clon->getChild('group')->appendChild(new FieldNode($field));
-		return $clon;
-	}
-	public function order($type, array $fields)
-	{
-		$clon = clone $this;
-		foreach ($fields as $field)
-			$clon->getChild('order')->appendChild(new FieldNode(sprintf('%s %s', $field, $type)));
+        public function group(...$fields)
+        {
+                $clon = clone $this;
+                foreach ($fields as $field)
+                        $clon->getChild('group')->appendChild(new FieldNode($field));
+                return $clon;
+        }
+        public function groupBy(...$fields)
+        {
+                $clon = clone $this;
+                return $clon->group(...$fields);
+        }
+        public function order($type, array $fields)
+        {
+                $clon = clone $this;
+                foreach ($fields as $field)
+                        $clon->getChild('order')->appendChild(new FieldNode(sprintf('%s %s', $field, $type)));
 		return $clon;
 	}
 	public function desc(...$fields)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $crud->where(['name__startWith' => 'Al']);
 
 ```php
 $rows = $crud
-    ->group('status')
+    ->groupBy('status')
     ->order('DESC', ['created_at'])
     ->limit(10)
     ->offset(20)

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -54,4 +54,21 @@ class QueryBuilderTest extends TestCase
         $msg = $query->buildSelect();
         $this->assertEquals('SELECT * FROM users u LEFT JOIN profiles p ON u.id = p.user_id', $msg->readMessage());
     }
+
+    public function testGroupByAlias()
+    {
+        $groupSql = (new Query())
+            ->from('users')
+            ->group('status')
+            ->buildSelect()
+            ->readMessage();
+
+        $groupBySql = (new Query())
+            ->from('users')
+            ->groupBy('status')
+            ->buildSelect()
+            ->readMessage();
+
+        $this->assertEquals($groupSql, $groupBySql);
+    }
 }


### PR DESCRIPTION
## Summary
- add `groupBy()` helper in `Query`
- test `groupBy()` alias
- document `groupBy` usage in README

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6866c1d1e5ec832c9e87141f3133f5c2