### PR TITLE
Add grouping method to ResultIterator

### DIFF
--- a/DBAL/ResultIterator.php
+++ b/DBAL/ResultIterator.php
@@ -102,4 +102,17 @@ class ResultIterator implements \Iterator, \JsonSerializable
                 $this->rewind();
                 return $this->rows;
         }
+
+        public function groupBy($key)
+        {
+                $groups = [];
+                $this->rewind();
+                foreach ($this as $row) {
+                        $groupKey = is_callable($key)
+                                ? $key($row)
+                                : ($row[$key] ?? null);
+                        $groups[$groupKey][] = $row;
+                }
+                return $groups;
+        }
 }

--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ foreach ($crudWithMapper->select() as $row) {
 }
 ```
 
+### Grouping results
+
+`ResultIterator` instances can group rows by a field name or a callback with `groupBy()`:
+
+```php
+$users = $crud->select();
+
+$byStatus = $users->groupBy('status');
+
+$byLetter = $users->groupBy(function ($row) {
+    return $row['name'][0];
+});
+```
+
 ### Middlewares
 
 Middlewares allow you to intercept query execution for tasks like logging or

--- a/tests/ResultIteratorGroupByTest.php
+++ b/tests/ResultIteratorGroupByTest.php
@@ -1,0 +1,35 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+
+class ResultIteratorGroupByTest extends TestCase
+{
+    private function pdoWithData()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, status TEXT)');
+        $pdo->exec('INSERT INTO t(name, status) VALUES ("Alice", "active"), ("Bob", "inactive"), ("Carol", "active")');
+        return $pdo;
+    }
+
+    public function testGroupByStringKey()
+    {
+        $pdo = $this->pdoWithData();
+        $crud = (new Crud($pdo))->from('t');
+        $groups = $crud->select()->groupBy('status');
+        $this->assertCount(2, $groups['active']);
+        $this->assertCount(1, $groups['inactive']);
+    }
+
+    public function testGroupByCallback()
+    {
+        $pdo = $this->pdoWithData();
+        $crud = (new Crud($pdo))->from('t');
+        $groups = $crud->select()->groupBy(function ($row) {
+            return $row['name'][0];
+        });
+        $this->assertArrayHasKey('A', $groups);
+        $this->assertArrayHasKey('B', $groups);
+        $this->assertArrayHasKey('C', $groups);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ResultIterator::groupBy()` for grouping rows by key or callback
- document grouping feature in README
- test grouping by column and by callback

## Testing
- `vendor/bin/phpunit tests/ResultIteratorGroupByTest.php` *(fails: No such file or directory)*
- `phpunit tests/ResultIteratorGroupByTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c2bf375c832c89d008e4a67959c1