### PR TITLE
Add transaction and unit of work middlewares

### DIFF
--- a/DBAL/TransactionMiddleware.php
+++ b/DBAL/TransactionMiddleware.php
@@ -1,0 +1,52 @@
+<?php
+namespace DBAL;
+
+use PDO;
+use DBAL\QueryBuilder\MessageInterface;
+
+class TransactionMiddleware implements MiddlewareInterface
+{
+    private $pdo;
+    private $log = [];
+    private $inTx = false;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function __invoke(MessageInterface $msg): void
+    {
+        // record transaction state on each query
+        $this->log[] = $this->pdo->inTransaction();
+        $this->inTx = $this->pdo->inTransaction();
+    }
+
+    public function begin(): void
+    {
+        $this->pdo->beginTransaction();
+        $this->inTx = true;
+    }
+
+    public function commit(): void
+    {
+        $this->pdo->commit();
+        $this->inTx = false;
+    }
+
+    public function rollback(): void
+    {
+        $this->pdo->rollBack();
+        $this->inTx = false;
+    }
+
+    public function getLog(): array
+    {
+        return $this->log;
+    }
+
+    public function inTransaction(): bool
+    {
+        return $this->inTx;
+    }
+}

--- a/DBAL/UnitOfWorkMiddleware.php
+++ b/DBAL/UnitOfWorkMiddleware.php
@@ -1,0 +1,67 @@
+<?php
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+use Exception;
+
+class UnitOfWorkMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterface
+{
+    private $tx;
+    private $news = [];
+    private $dirty = [];
+    private $delete = [];
+
+    public function __construct(TransactionMiddleware $tx)
+    {
+        $this->tx = $tx;
+    }
+
+    public function __invoke(MessageInterface $msg): void
+    {
+        // no-op
+    }
+
+    public function registerNew(string $table, array $data): void
+    {
+        $this->news[] = ['table' => $table, 'data' => $data];
+    }
+
+    public function registerDirty(string $table, array $data, array $where): void
+    {
+        $this->dirty[] = ['table' => $table, 'data' => $data, 'where' => $where];
+    }
+
+    public function registerDelete(string $table, array $where): void
+    {
+        $this->delete[] = ['table' => $table, 'where' => $where];
+    }
+
+    public function commit(Crud $crud): void
+    {
+        $this->tx->begin();
+        try {
+            foreach ($this->news as $n) {
+                $crud->from($n['table'])->insert($n['data']);
+            }
+            foreach ($this->dirty as $u) {
+                $crud->from($u['table'])->where($u['where'])->update($u['data']);
+            }
+            foreach ($this->delete as $d) {
+                $crud->from($d['table'])->where($d['where'])->delete();
+            }
+            $this->tx->commit();
+        } catch (Exception $e) {
+            $this->tx->rollback();
+            throw $e;
+        } finally {
+            $this->clear();
+        }
+    }
+
+    private function clear(): void
+    {
+        $this->news = [];
+        $this->dirty = [];
+        $this->delete = [];
+    }
+}

--- a/README.md
+++ b/README.md
@@ -271,3 +271,24 @@ $user = iterator_to_array($crud->where(['id' => 1])->select())[0];
 $profile = $user['profile'];
 echo $profile['photo'];
 ```
+
+### Transaction and Unit of Work middlewares
+
+`TransactionMiddleware` exposes helpers to control database transactions while `UnitOfWorkMiddleware` batches operations to be executed atomically.
+
+```php
+$tx  = new DBAL\TransactionMiddleware($pdo);
+$uow = new DBAL\UnitOfWorkMiddleware($tx);
+
+$crud = (new DBAL\Crud($pdo))
+    ->from('users')
+    ->withMiddleware($uow)
+    ->withMiddleware($tx);
+
+$crud->registerNew('users', ['name' => 'Alice']);
+$crud->commit();
+
+$crud->begin();
+$crud->insert(['name' => 'Bob']);
+$crud->rollback();
+```

--- a/tests/TransactionUnitOfWorkMiddlewareTest.php
+++ b/tests/TransactionUnitOfWorkMiddlewareTest.php
@@ -1,0 +1,46 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\TransactionMiddleware;
+use DBAL\UnitOfWorkMiddleware;
+
+class TransactionUnitOfWorkMiddlewareTest extends TestCase
+{
+    private function createPdo()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        return $pdo;
+    }
+
+    public function testCommitRunsInsideTransaction()
+    {
+        $pdo = $this->createPdo();
+        $tx = new TransactionMiddleware($pdo);
+        $uow = new UnitOfWorkMiddleware($tx);
+        $crud = (new Crud($pdo))->from('items')->withMiddleware($uow)->withMiddleware($tx);
+
+        $crud->registerNew('items', ['name' => 'A']);
+        $crud->commit();
+
+        $rows = iterator_to_array($crud->select());
+        $this->assertCount(1, $rows);
+        $this->assertTrue($tx->getLog()[0]);
+    }
+
+    public function testRollbackUndoesChanges()
+    {
+        $pdo = $this->createPdo();
+        $tx = new TransactionMiddleware($pdo);
+        $uow = new UnitOfWorkMiddleware($tx);
+        $crud = (new Crud($pdo))->from('items')->withMiddleware($uow)->withMiddleware($tx);
+
+        $crud->begin();
+        $crud->insert(['name' => 'A']);
+        $crud->rollback();
+
+        $rows = iterator_to_array($crud->select());
+        $this->assertCount(0, $rows);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `TransactionMiddleware` to manage PDO transactions
- implement `UnitOfWorkMiddleware` to batch operations in a single transaction
- test transactional middlewares
- document usage of transaction and unit of work middlewares

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c495d830832c9c2fa2a14ee1ef35