### PR TITLE
Add GlobalFilterMiddleware

### DIFF
--- a/DBAL/GlobalFilterMiddleware.php
+++ b/DBAL/GlobalFilterMiddleware.php
@@ -1,0 +1,82 @@
+<?php
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+use DBAL\QueryBuilder\Message;
+
+class GlobalFilterMiddleware implements MiddlewareInterface
+{
+    private $tableFilters = [];
+    private $globalFilters = [];
+
+    public function __construct(array $tableFilters = [], array $globalFilters = [])
+    {
+        foreach ($tableFilters as $table => $filters) {
+            $this->tableFilters[$table] = is_array($filters) ? $filters : [$filters];
+        }
+        foreach ($globalFilters as $f) {
+            $this->globalFilters[] = $f;
+        }
+    }
+
+    public function addFilter($table, callable $filter): self
+    {
+        if ($table === null) {
+            $this->globalFilters[] = $filter;
+        } else {
+            if (!isset($this->tableFilters[$table])) {
+                $this->tableFilters[$table] = [];
+            }
+            $this->tableFilters[$table][] = $filter;
+        }
+        return $this;
+    }
+
+    public function __invoke(MessageInterface $msg): void
+    {
+        if ($msg->type() !== MessageInterface::MESSAGE_TYPE_SELECT) {
+            return;
+        }
+
+        $tables = $this->extractTables($msg->readMessage());
+        $filters = $this->globalFilters;
+        foreach ($tables as $t) {
+            if (isset($this->tableFilters[$t])) {
+                $filters = array_merge($filters, $this->tableFilters[$t]);
+            }
+        }
+
+        foreach ($filters as $f) {
+            $new = $f($msg);
+            if ($new instanceof MessageInterface) {
+                $this->apply($msg, $new);
+            }
+        }
+    }
+
+    private function apply(MessageInterface $dest, MessageInterface $src): void
+    {
+        if (!($dest instanceof Message) || !($src instanceof Message)) {
+            return;
+        }
+        $ref = new \ReflectionObject($dest);
+        $prop = $ref->getProperty('message');
+        $prop->setAccessible(true);
+        $prop->setValue($dest, $src->readMessage());
+        $prop = $ref->getProperty('values');
+        $prop->setAccessible(true);
+        $prop->setValue($dest, $src->getValues());
+    }
+
+    private function extractTables(string $sql): array
+    {
+        $tables = [];
+        if (preg_match_all('/\b(?:FROM|JOIN|UPDATE|INTO)\s+([`"\w\\.]+)(?:\s|$)/i', $sql, $m)) {
+            foreach ($m[1] as $t) {
+                $parts = preg_split('/\s+/', $t);
+                $tables[] = trim($parts[0], '`"');
+            }
+        }
+        return array_unique($tables);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -271,3 +271,23 @@ $user = iterator_to_array($crud->where(['id' => 1])->select())[0];
 $profile = $user['profile'];
 echo $profile['photo'];
 ```
+
+### Global filter middleware
+
+`GlobalFilterMiddleware` can automatically append extra conditions to every SELECT statement. Filters can be declared globally or per table and work together with other middlewares.
+
+```php
+use DBAL\GlobalFilterMiddleware;
+
+$mw = new GlobalFilterMiddleware([], [
+    function ($m) {
+        return stripos($m->readMessage(), 'WHERE') !== false
+            ? $m->replace('WHERE', 'WHERE deleted = 0 AND')
+            : $m->insertAfter('WHERE deleted = 0');
+    }
+]);
+
+$crud = (new DBAL\Crud($pdo))
+    ->from('users')
+    ->withMiddleware($mw);
+```

--- a/tests/GlobalFilterMiddlewareTest.php
+++ b/tests/GlobalFilterMiddlewareTest.php
@@ -1,0 +1,81 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\GlobalFilterMiddleware;
+use DBAL\QueryBuilder\MessageInterface;
+
+class GlobalFilterMiddlewareTest extends TestCase
+{
+    private function createPdo()
+    {
+        return new PDO('sqlite::memory:');
+    }
+
+    public function testGlobalFilterIsApplied()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, deleted INTEGER)');
+        $pdo->exec('INSERT INTO items(name, deleted) VALUES ("A",0),("B",1)');
+
+        $mw = new GlobalFilterMiddleware([], [
+            function (MessageInterface $m) {
+                return stripos($m->readMessage(), 'WHERE') !== false
+                    ? $m->replace('WHERE', 'WHERE deleted = 0 AND')
+                    : $m->insertAfter('WHERE deleted = 0');
+            }
+        ]);
+
+        $log = [];
+        $logger = function (MessageInterface $m) use (&$log) { $log[] = $m->readMessage(); };
+
+        $crud = (new Crud($pdo))
+            ->from('items')
+            ->withMiddleware($mw)
+            ->withMiddleware($logger);
+
+        $rows = iterator_to_array($crud->select());
+
+        $this->assertCount(1, $rows);
+        $this->assertStringContainsString('deleted = 0', $log[0]);
+    }
+
+    public function testTableFilterIsAppliedOnlyForMatchingTable()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, deleted INTEGER)');
+        $pdo->exec('CREATE TABLE posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT)');
+        $pdo->exec('INSERT INTO users(name, deleted) VALUES ("A",0),("B",1)');
+        $pdo->exec('INSERT INTO posts(title) VALUES ("P1"),("P2")');
+
+        $mw = new GlobalFilterMiddleware([
+            'users' => [
+                function (MessageInterface $m) {
+                    return stripos($m->readMessage(), 'WHERE') !== false
+                        ? $m->replace('WHERE', 'WHERE deleted = 0 AND')
+                        : $m->insertAfter('WHERE deleted = 0');
+                }
+            ]
+        ]);
+
+        $log = [];
+        $logger = function (MessageInterface $m) use (&$log) { $log[] = $m->readMessage(); };
+
+        $usersCrud = (new Crud($pdo))
+            ->from('users')
+            ->withMiddleware($mw)
+            ->withMiddleware($logger);
+
+        $postsCrud = (new Crud($pdo))
+            ->from('posts')
+            ->withMiddleware($mw)
+            ->withMiddleware($logger);
+
+        $userRows = iterator_to_array($usersCrud->select());
+        $postRows = iterator_to_array($postsCrud->select());
+
+        $this->assertCount(1, $userRows);
+        $this->assertCount(2, $postRows);
+        $this->assertStringContainsString('deleted = 0', $log[0]);
+        $this->assertStringNotContainsString('deleted = 0', $log[1]);
+    }
+}


### PR DESCRIPTION
## Summary
- implement new GlobalFilterMiddleware for applying query filters
- add corresponding unit tests
- document usage in README

## Testing
- `composer install` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c49ebff4832c87cf3b3af0646f28