### PR TITLE
Add bulk insert capability

### DIFF
--- a/DBAL/Crud.php
+++ b/DBAL/Crud.php
@@ -114,6 +114,21 @@ class Crud extends Query
                 $stm->execute($message->getValues());
                 return $this->connection->lastInsertId();
         }
+        public function bulkInsert(array $rows)
+        {
+                foreach ($this->middlewares as $mw) {
+                        if ($mw instanceof EntityValidationInterface) {
+                                foreach ($rows as $row) {
+                                        $mw->beforeInsert($this->primaryTable(), $row);
+                                }
+                        }
+                }
+                $message = $this->buildBulkInsert($rows);
+                $this->runMiddlewares($message);
+                $stm = $this->connection->prepare($message->readMessage());
+                $stm->execute($message->getValues());
+                return $stm->rowCount();
+        }
         public function update(array $fields)
         {
                 foreach ($this->middlewares as $mw) {

--- a/DBAL/QueryBuilder/Node/ChangeNode.php
+++ b/DBAL/QueryBuilder/Node/ChangeNode.php
@@ -6,25 +6,46 @@ use DBAL\QueryBuilder\Message;
 
 class ChangeNode extends NotImplementedNode
 {
-	protected $isEmpty = false;
-	protected $fields = [];
-	public function setFields(array $fields)
-	{
-		$this->fields = $fields;
-	}
-	public function send(MessageInterface $message)
-	{
-		$msg = null;
-		if ($message->type() == MessageInterface::MESSAGE_TYPE_INSERT) {
-			$msg = new Message(MessageInterface::MESSAGE_TYPE_INSERT, 'VALUES', array_values($this->fields));
-			$fields = sprintf('(%s)', implode(', ', array_keys($this->fields)));
-			$msg = $msg->insertBefore($fields);
-			$q = sprintf('(%s)', implode(', ', array_fill(0, sizeof($this->fields), '?')));
-			$msg = $msg->insertAfter($q);
-		} else if ($message->type() == MessageInterface::MESSAGE_TYPE_UPDATE) {
-			$msg = new Message(MessageInterface::MESSAGE_TYPE_UPDATE, 'SET', array_values($this->fields));
-			$fields = implode(', ',
-				array_map(
+        protected $isEmpty = false;
+        protected $fields = [];
+        protected $rows = null;
+        public function setFields(array $fields)
+        {
+                $this->fields = $fields;
+        }
+        public function setRows(array $rows)
+        {
+                $this->rows = $rows;
+        }
+        public function send(MessageInterface $message)
+        {
+                $msg = null;
+                if ($message->type() == MessageInterface::MESSAGE_TYPE_INSERT) {
+                        if ($this->rows !== null) {
+                                $first = $this->rows[0] ?? [];
+                                $cols = array_keys($first);
+                                $placeholders = '(' . implode(', ', array_fill(0, count($cols), '?')) . ')';
+                                $values = [];
+                                $q = [];
+                                foreach ($this->rows as $row) {
+                                        $q[] = $placeholders;
+                                        $values = array_merge($values, array_values($row));
+                                }
+                                $msg = new Message(MessageInterface::MESSAGE_TYPE_INSERT, 'VALUES', $values);
+                                $fields = sprintf('(%s)', implode(', ', $cols));
+                                $msg = $msg->insertBefore($fields);
+                                $msg = $msg->insertAfter(implode(', ', $q));
+                        } else {
+                                $msg = new Message(MessageInterface::MESSAGE_TYPE_INSERT, 'VALUES', array_values($this->fields));
+                                $fields = sprintf('(%s)', implode(', ', array_keys($this->fields)));
+                                $msg = $msg->insertBefore($fields);
+                                $q = sprintf('(%s)', implode(', ', array_fill(0, sizeof($this->fields), '?')));
+                                $msg = $msg->insertAfter($q);
+                        }
+                } else if ($message->type() == MessageInterface::MESSAGE_TYPE_UPDATE) {
+                        $msg = new Message(MessageInterface::MESSAGE_TYPE_UPDATE, 'SET', array_values($this->fields));
+                        $fields = implode(', ',
+                                array_map(
 					function($field)
 					{
 						return sprintf('%s = ?', $field);
@@ -32,9 +53,10 @@ class ChangeNode extends NotImplementedNode
 					array_keys($this->fields)
 				)
 			);
-			$msg = $msg->insertAfter($fields);
-		}
-		$this->fields = [];
-		return ($msg != null)? $message->insertAfter($msg->readMessage())->addValues($msg->getValues()) : $message;
-	}
+                        $msg = $msg->insertAfter($fields);
+                }
+                $this->fields = [];
+                $this->rows = null;
+                return ($msg != null)? $message->insertAfter($msg->readMessage())->addValues($msg->getValues()) : $message;
+        }
 }

--- a/DBAL/QueryBuilder/Query.php
+++ b/DBAL/QueryBuilder/Query.php
@@ -152,19 +152,27 @@ class Query extends QueryNode
 		}
 		return $message;
 	}
-	public function buildInsert(array $fields)
-	{
-		$clon = clone $this;
-		$message = new Message(MessageInterface::MESSAGE_TYPE_INSERT);
-		$clon->getChild('change')->setFields($fields);
-		$message = $clon->send($message);
-		return $message;
-	}
-	public function buildUpdate(array $fields)
-	{
-		$clon = clone $this;
-		$message = new Message(MessageInterface::MESSAGE_TYPE_UPDATE);
-		$clon->getChild('change')->setFields($fields);
+        public function buildInsert(array $fields)
+        {
+                $clon = clone $this;
+                $message = new Message(MessageInterface::MESSAGE_TYPE_INSERT);
+                $clon->getChild('change')->setFields($fields);
+                $message = $clon->send($message);
+                return $message;
+        }
+        public function buildBulkInsert(array $rows)
+        {
+                $clon = clone $this;
+                $message = new Message(MessageInterface::MESSAGE_TYPE_INSERT);
+                $clon->getChild('change')->setRows($rows);
+                $message = $clon->send($message);
+                return $message;
+        }
+        public function buildUpdate(array $fields)
+        {
+                $clon = clone $this;
+                $message = new Message(MessageInterface::MESSAGE_TYPE_UPDATE);
+                $clon->getChild('change')->setFields($fields);
 		$message = $clon->send($message);
 		return $message;
 	}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ $id = $crud->insert([
 ]);
 ```
 
+### Bulk insert
+
+```php
+$count = $crud->bulkInsert([
+    ['name' => 'Alice'],
+    ['name' => 'Bob']
+]);
+```
+
 ### Select with `where`
 
 ```php

--- a/tests/CrudBulkInsertTest.php
+++ b/tests/CrudBulkInsertTest.php
@@ -1,0 +1,27 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+
+class CrudBulkInsertTest extends TestCase
+{
+    private function createPdo()
+    {
+        return new PDO('sqlite::memory:');
+    }
+
+    public function testBulkInsertInsertsMultipleRows()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+
+        $crud = (new Crud($pdo))->from('items');
+        $count = $crud->bulkInsert([
+            ['name' => 'A'],
+            ['name' => 'B'],
+            ['name' => 'C'],
+        ]);
+        $this->assertEquals(3, $count);
+        $rows = iterator_to_array($crud->select());
+        $this->assertCount(3, $rows);
+    }
+}


### PR DESCRIPTION
## Summary
- support inserting multiple rows at once in `ChangeNode`
- expose `buildBulkInsert()` in the query builder
- add `bulkInsert()` to `Crud`
- test bulk insertion with SQLite
- document bulk insert usage

## Testing
- `vendor/bin/phpunit -c phpunit.xml tests/CrudBulkInsertTest.php` *(fails: `No such file or directory`)*
- `vendor/bin/phpunit` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6866c6991c28832c8287bac35f456b4f