### PR TITLE
Implement stream generator

### DIFF
--- a/DBAL/Crud.php
+++ b/DBAL/Crud.php
@@ -4,6 +4,7 @@ namespace DBAL;
 use DBAL\QueryBuilder\Query;
 use DBAL\QueryBuilder\MessageInterface;
 use DBAL\RelationDefinition;
+use Generator;
 
 class Crud extends Query
 {
@@ -100,6 +101,25 @@ class Crud extends Query
                         $relations,
                         $this->with
                 );
+        }
+
+        public function stream(...$args)
+        {
+                $callback = null;
+                if (isset($args[0]) && is_callable($args[0])) {
+                        $callback = array_shift($args);
+                }
+                $message = $this->buildSelect(...$args);
+                $relations = $this->collectRelations($this->primaryTable());
+                $generator = new ResultGenerator(
+                        $this->connection,
+                        $message,
+                        $this->mappers,
+                        $this->middlewares,
+                        $relations,
+                        $this->with
+                );
+                return $generator->getIterator($callback);
         }
         public function insert(array $fields)
         {

--- a/DBAL/ResultGenerator.php
+++ b/DBAL/ResultGenerator.php
@@ -1,0 +1,105 @@
+<?php
+namespace DBAL;
+
+use Generator;
+use PDO;
+use DBAL\QueryBuilder\MessageInterface;
+
+class ResultGenerator
+{
+    private $pdo;
+    private $message;
+    private $mappers;
+    private $middlewares;
+    private $relations;
+    private $eagerRelations;
+
+    public function __construct(PDO $pdo, MessageInterface $message, array $mappers = [], array $middlewares = [], array $relations = [], array $eagerRelations = [])
+    {
+        $this->pdo = $pdo;
+        $this->message = $message;
+        $this->mappers = $mappers;
+        $this->middlewares = $middlewares;
+        $this->relations = $relations;
+        $this->eagerRelations = $eagerRelations;
+    }
+
+    private function applyMappers($row)
+    {
+        foreach ($this->mappers as $mapper) {
+            $row = $mapper($row);
+        }
+        return $row;
+    }
+
+    private function applyLazyRelations($row)
+    {
+        foreach ($this->relations as $name => $rel) {
+            if (!in_array($name, $this->eagerRelations)) {
+                $pdo = $this->pdo;
+                $middlewares = $this->middlewares;
+                $value = $row[$rel['localKey']];
+                $loader = function () use ($pdo, $middlewares, $rel, $value) {
+                    $crud = new Crud($pdo);
+                    foreach ($middlewares as $mw) {
+                        $crud = $crud->withMiddleware($mw);
+                    }
+                    $crud = $crud->from($rel['table'])->where([
+                        $rel['foreignKey'] . '__eq' => $value,
+                    ]);
+                    $rows = iterator_to_array($crud->select());
+                    if (in_array($rel['type'], ['hasOne', 'belongsTo'])) {
+                        return $rows[0] ?? null;
+                    }
+                    return $rows;
+                };
+                $row[$name] = new LazyRelation($loader);
+            }
+        }
+        return $row;
+    }
+
+    public function getIterator(callable $callback = null): Generator
+    {
+        foreach ($this->middlewares as $mw) {
+            $mw($this->message);
+        }
+
+        foreach ($this->middlewares as $mw) {
+            if (method_exists($mw, 'fetch')) {
+                $cached = $mw->fetch($this->message);
+                if ($cached !== null) {
+                    foreach ($cached as $row) {
+                        $row = $this->applyMappers($row);
+                        $row = $this->applyLazyRelations($row);
+                        if ($callback) {
+                            $callback($row);
+                        }
+                        yield $row;
+                    }
+                    return;
+                }
+            }
+        }
+
+        $stm = $this->pdo->prepare($this->message->readMessage());
+        $stm->execute($this->message->getValues());
+
+        $rows = [];
+        while ($row = $stm->fetch(PDO::FETCH_ASSOC)) {
+            $rows[] = $row;
+            $row = $this->applyMappers($row);
+            $row = $this->applyLazyRelations($row);
+            if ($callback) {
+                $callback($row);
+            }
+            yield $row;
+        }
+
+        foreach ($this->middlewares as $mw) {
+            if (method_exists($mw, 'save')) {
+                $mw->save($this->message, $rows);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -131,6 +131,23 @@ $byLetter = $users->groupBy(function ($row) {
 });
 ```
 
+### Streaming results
+
+`Crud::stream()` returns a generator that yields each row lazily. A callback can
+be provided to process rows as they are produced.
+
+```php
+$generator = $crud->stream('id', 'name');
+
+foreach ($generator as $row) {
+    echo $row['name'];
+}
+
+$crud->stream(function ($row) {
+    echo $row['name'];
+}, 'id', 'name');
+```
+
 ### Middlewares
 
 Middlewares allow you to intercept query execution for tasks like logging or

--- a/tests/CrudStreamTest.php
+++ b/tests/CrudStreamTest.php
@@ -1,0 +1,40 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+
+class CrudStreamTest extends TestCase
+{
+    private function pdoWithData()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $pdo->exec('INSERT INTO t(name) VALUES ("A"), ("B")');
+        return $pdo;
+    }
+
+    public function testStreamReturnsGenerator()
+    {
+        $crud = (new Crud($this->pdoWithData()))->from('t');
+        $gen = $crud->stream('name');
+        $this->assertInstanceOf(Generator::class, $gen);
+        $rows = iterator_to_array($gen);
+        $this->assertEquals([
+            ['name' => 'A'],
+            ['name' => 'B'],
+        ], $rows);
+    }
+
+    public function testStreamWithCallback()
+    {
+        $pdo = $this->pdoWithData();
+        $crud = (new Crud($pdo))->from('t');
+        $count = 0;
+        $gen = $crud->stream(function ($row) use (&$count) {
+            $count++;
+        }, 'name');
+        foreach ($gen as $_) {
+            // iterate
+        }
+        $this->assertEquals(2, $count);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ResultGenerator` class to lazily fetch rows with `yield`
- expose new `Crud::stream()` method returning the generator
- document streaming in README
- add unit tests for the new method

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c6c36c70832c9acf349f1ee50417