### PR TITLE
Add schema builders with lambda column support

### DIFF
--- a/DBAL/Schema/SchemaColumnBuilder.php
+++ b/DBAL/Schema/SchemaColumnBuilder.php
@@ -1,0 +1,59 @@
+<?php
+namespace DBAL\Schema;
+
+class SchemaColumnBuilder
+{
+    private $name;
+    private $type = '';
+    private $constraints = [];
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function type(string $type): self
+    {
+        $this->type = strtoupper($type);
+        return $this;
+    }
+
+    public function integer(): self
+    {
+        return $this->type('INTEGER');
+    }
+
+    public function text(): self
+    {
+        return $this->type('TEXT');
+    }
+
+    public function real(): self
+    {
+        return $this->type('REAL');
+    }
+
+    public function primaryKey(): self
+    {
+        $this->constraints[] = 'PRIMARY KEY';
+        return $this;
+    }
+
+    public function autoIncrement(): self
+    {
+        $this->constraints[] = 'AUTOINCREMENT';
+        return $this;
+    }
+
+    public function build(): string
+    {
+        $parts = [$this->name];
+        if ($this->type) {
+            $parts[] = $this->type;
+        }
+        if ($this->constraints) {
+            $parts[] = implode(' ', $this->constraints);
+        }
+        return implode(' ', $parts);
+    }
+}

--- a/DBAL/Schema/SchemaTableBuilder.php
+++ b/DBAL/Schema/SchemaTableBuilder.php
@@ -1,0 +1,39 @@
+<?php
+namespace DBAL\Schema;
+
+class SchemaTableBuilder
+{
+    private $name;
+    /** @var SchemaColumnBuilder[] */
+    private $columns = [];
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function column(string $name, $typeOrCallback): self
+    {
+        return $this->addColumn($name, $typeOrCallback);
+    }
+
+    public function addColumn(string $name, $typeOrCallback): self
+    {
+        $builder = new SchemaColumnBuilder($name);
+        if (is_callable($typeOrCallback)) {
+            $typeOrCallback($builder);
+        } else {
+            $builder->type($typeOrCallback);
+        }
+        $this->columns[] = $builder;
+        return $this;
+    }
+
+    public function build(): string
+    {
+        $cols = array_map(function (SchemaColumnBuilder $col) {
+            return $col->build();
+        }, $this->columns);
+        return sprintf('CREATE TABLE %s (%s)', $this->name, implode(', ', $cols));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -317,3 +317,20 @@ $crud = (new DBAL\Crud($pdo))
     ->from('users')
     ->withMiddleware($mw);
 ```
+
+### Schema builder
+
+`SchemaTableBuilder` can create `CREATE TABLE` statements programmatically. Columns may be defined using a lambda that receives a `SchemaColumnBuilder` instance:
+
+```php
+use DBAL\Schema\SchemaTableBuilder;
+
+$table = (new SchemaTableBuilder('users'))
+    ->column('id', function ($c) {
+        $c->integer()->primaryKey()->autoIncrement();
+    })
+    ->column('name', 'TEXT');
+
+$sql = $table->build();
+// "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)"
+```

--- a/tests/SchemaTableBuilderTest.php
+++ b/tests/SchemaTableBuilderTest.php
@@ -1,0 +1,34 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Schema\SchemaTableBuilder;
+
+class SchemaTableBuilderTest extends TestCase
+{
+    public function testLambdaColumnDefinition()
+    {
+        $table = new SchemaTableBuilder('users');
+        $table->column('id', function ($c) {
+            $c->integer()->primaryKey()->autoIncrement();
+        });
+        $table->column('name', function ($c) {
+            $c->text();
+        });
+        $this->assertEquals(
+            'CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)',
+            $table->build()
+        );
+    }
+
+    public function testAddColumnWithStringType()
+    {
+        $table = new SchemaTableBuilder('items');
+        $table->addColumn('id', function ($c) {
+            $c->integer()->primaryKey();
+        });
+        $table->addColumn('name', 'TEXT');
+        $this->assertEquals(
+            'CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)',
+            $table->build()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SchemaColumnBuilder` for defining column types and constraints
- add `SchemaTableBuilder` that can define columns via a callback or type string
- document schema builder usage in `README.md`
- add tests for lambda-based column definitions

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ca6b617c832cb62a6e911c06c002