### PR TITLE
Fix schema builder parameter docs and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,3 +334,13 @@ $table = (new SchemaTableBuilder('users'))
 $sql = $table->build();
 // "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)"
 ```
+After creating the table, additional columns may be appended using `addColumn()`.
+
+```php
+$table->addColumn('age', function ($c) {
+    $c->integer();
+});
+
+$sql = $table->build();
+// "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, age INTEGER)"
+```

--- a/tests/SchemaTableBuilderTest.php
+++ b/tests/SchemaTableBuilderTest.php
@@ -31,4 +31,30 @@ class SchemaTableBuilderTest extends TestCase
             $table->build()
         );
     }
+
+    public function testColumnWithStringType()
+    {
+        $table = new SchemaTableBuilder('products');
+        $table->column('id', 'INTEGER');
+        $table->column('name', 'TEXT');
+        $this->assertEquals(
+            'CREATE TABLE products (id INTEGER, name TEXT)',
+            $table->build()
+        );
+    }
+
+    public function testAddColumnAfterBuild()
+    {
+        $table = new SchemaTableBuilder('logs');
+        $table->column('id', 'INTEGER');
+        $this->assertEquals(
+            'CREATE TABLE logs (id INTEGER)',
+            $table->build()
+        );
+        $table->addColumn('msg', 'TEXT');
+        $this->assertEquals(
+            'CREATE TABLE logs (id INTEGER, msg TEXT)',
+            $table->build()
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- document using `addColumn()` after initial columns
- cover `column()` with string type and altering via `addColumn()` in unit tests

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cbf8c960832c86ebcaa208b42226