### PR TITLE
Enhance DevelopmentErrorMiddleware with options

### DIFF
--- a/DBAL/DevelopmentErrorMiddleware.php
+++ b/DBAL/DevelopmentErrorMiddleware.php
@@ -5,15 +5,24 @@ use DBAL\QueryBuilder\MessageInterface;
 
 class DevelopmentErrorMiddleware implements MiddlewareInterface
 {
-    private $toStderr;
-    private $path;
+    private $console;
+    private $persistPath;
+    private $theme;
+    private $fontSize;
 
-    public function __construct(bool $toStderr = false, string $path = null)
+    public function __construct(array $options = [])
     {
-        $this->toStderr = $toStderr;
-        $this->path = rtrim($path ?: __DIR__ . '/../errors', '/');
-        if (!is_dir($this->path)) {
-            @mkdir($this->path, 0777, true);
+        $this->console = isset($options['console']) ? (bool)$options['console'] : false;
+        $this->persistPath = isset($options['persistPath']) ? rtrim((string)$options['persistPath'], '/') : null;
+
+        $theme = isset($options['theme']) ? $options['theme'] : 'light';
+        $this->theme = in_array($theme, ['light', 'dark'], true) ? $theme : 'light';
+
+        $fontSize = isset($options['fontSize']) ? $options['fontSize'] : 'medium';
+        $this->fontSize = in_array($fontSize, ['small', 'medium', 'large'], true) ? $fontSize : 'medium';
+
+        if ($this->persistPath !== null && !is_dir($this->persistPath)) {
+            @mkdir($this->persistPath, 0777, true);
         }
         set_exception_handler([$this, 'handleException']);
     }
@@ -26,17 +35,17 @@ class DevelopmentErrorMiddleware implements MiddlewareInterface
     public function handleException(\Throwable $e): void
     {
         $html = $this->renderHtml($e);
-        if (PHP_SAPI === 'cli') {
-            $text = $e->getMessage() . PHP_EOL . $e->getTraceAsString() . PHP_EOL;
-            if ($this->toStderr) {
-                file_put_contents('php://stderr', $text);
-            } else {
-                echo $text;
-            }
-        } else {
+
+        if ($this->console) {
+            $text = $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() . PHP_EOL . $e->getTraceAsString() . PHP_EOL;
+            file_put_contents('php://stderr', $text);
+        } elseif (PHP_SAPI !== 'cli') {
             header('Content-Type: text/html; charset=utf-8');
             echo $html;
+        } else {
+            echo $e->getMessage() . PHP_EOL . $e->getTraceAsString() . PHP_EOL;
         }
+
         $this->persist($html);
         exit(1);
     }
@@ -45,12 +54,29 @@ class DevelopmentErrorMiddleware implements MiddlewareInterface
     {
         $message = htmlspecialchars($e->getMessage(), ENT_QUOTES, 'UTF-8');
         $trace = htmlspecialchars($e->getTraceAsString(), ENT_QUOTES, 'UTF-8');
+        $file = htmlspecialchars($e->getFile(), ENT_QUOTES, 'UTF-8');
+        $line = (int)$e->getLine();
+        $snippet = '';
+        if (is_file($e->getFile())) {
+            $lines = @file($e->getFile());
+            $start = max(0, $line - 3);
+            $slice = array_slice($lines, $start, 6, true);
+            foreach ($slice as $num => $code) {
+                $num++;
+                $code = htmlspecialchars(rtrim($code), ENT_QUOTES, 'UTF-8');
+                $indicator = $num === $line ? '>> ' : '   ';
+                $snippet .= $indicator . str_pad((string)$num, 4, ' ', STR_PAD_LEFT) . " | " . $code . "\n";
+            }
+        }
+
         return "<!DOCTYPE html>
 <html><head><meta charset='utf-8'><title>Application error</title>
 <link rel='stylesheet' href='style.css'>
-</head><body class='light font-medium'>
+</head><body class='{$this->theme} font-{$this->fontSize}'>
 <h1>An error occurred</h1>
 <p class='message'>{$message}</p>
+<p class='location'>{$file}:{$line}</p>
+<pre class='code'>{$snippet}</pre>
 <pre class='trace'>{$trace}</pre>
 <div class='controls'>Theme:
  <button onclick=\"setTheme('light')\">Light</button>
@@ -66,7 +92,7 @@ class DevelopmentErrorMiddleware implements MiddlewareInterface
 
     private function css(): string
     {
-        return "body{font-family:Arial,sans-serif;margin:20px;}body.light{background:#fff;color:#000;}body.dark{background:#000;color:#fff}.font-small{font-size:14px}.font-medium{font-size:18px}.font-large{font-size:22px}pre{white-space:pre-wrap}";
+        return "body{font-family:Arial,sans-serif;margin:20px;}body.light{background:#fff;color:#000;}body.dark{background:#000;color:#fff}.font-small{font-size:14px}.font-medium{font-size:18px}.font-large{font-size:22px}pre{white-space:pre-wrap}.location{margin-bottom:10px;font-style:italic}.code{background:#f5f5f5;padding:10px}";
     }
 
     private function js(): string
@@ -76,7 +102,11 @@ class DevelopmentErrorMiddleware implements MiddlewareInterface
 
     private function persist(string $html): void
     {
-        $dir = $this->path . '/' . date('Ymd_His');
+        if ($this->persistPath === null) {
+            return;
+        }
+
+        $dir = $this->persistPath . '/' . date('Ymd_His');
         if (!is_dir($dir)) {
             mkdir($dir, 0777, true);
         }

--- a/README.md
+++ b/README.md
@@ -338,10 +338,13 @@ $crud->alterTable('items')
 
 ### Development error middleware
 
-`DevelopmentErrorMiddleware` installs an exception handler that displays a basic HTML page whenever an uncaught exception happens. The page supports light and dark themes and allows switching between small, medium and large fonts. In console mode the middleware can optionally output the error to `STDERR`. Rendered pages are stored in a timestamped folder so they can be reviewed later.
+`DevelopmentErrorMiddleware` installs an exception handler that displays a basic HTML page whenever an uncaught exception happens. The page supports light and dark themes and allows switching between small, medium and large fonts. When `console` is enabled a text version of the error is written to `STDERR`. If `persistPath` is provided, rendered pages are stored in timestamped folders so they can be reviewed later.
 
 ```php
-$errors = new DBAL\DevelopmentErrorMiddleware(true, __DIR__.'/errors');
+$errors = new DBAL\DevelopmentErrorMiddleware([
+    'console'     => true,
+    'persistPath' => __DIR__.'/errors',
+]);
 $crud = (new DBAL\Crud($pdo))
     ->withMiddleware($errors);
 ```


### PR DESCRIPTION
## Summary
- add configurable options to DevelopmentErrorMiddleware
- improve HTML rendering and optional persistence
- document new usage example

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cddeaa64832cb26ce5a443d67135