### PR TITLE
Add DevelopmentErrorMiddleware test

### DIFF
--- a/DBAL/DevelopmentErrorMiddleware.php
+++ b/DBAL/DevelopmentErrorMiddleware.php
@@ -1,0 +1,41 @@
+<?php
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+class DevelopmentErrorMiddleware implements MiddlewareInterface
+{
+    private $dir;
+    private $console;
+    private $stream;
+
+    public function __construct(string $dir, bool $console = false, $stream = null)
+    {
+        $this->dir = $dir;
+        $this->console = $console;
+        $this->stream = $stream ?: fopen('php://stderr', 'w');
+    }
+
+    public function __invoke(MessageInterface $message): void
+    {
+        // no-op
+    }
+
+    public function register(): void
+    {
+        set_exception_handler([$this, 'handle']);
+    }
+
+    public function handle(\Throwable $e): void
+    {
+        if (!is_dir($this->dir)) {
+            mkdir($this->dir, 0777, true);
+        }
+        $file = $this->dir . '/' . uniqid('exception_', true) . '.html';
+        $body = '<html><body><pre>' . htmlspecialchars((string) $e) . '</pre></body></html>';
+        file_put_contents($file, $body);
+        if ($this->console) {
+            fwrite($this->stream, (string) $e);
+        }
+    }
+}

--- a/tests/DevelopmentErrorMiddlewareTest.php
+++ b/tests/DevelopmentErrorMiddlewareTest.php
@@ -1,0 +1,24 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\DevelopmentErrorMiddleware;
+
+class DevelopmentErrorMiddlewareTest extends TestCase
+{
+    public function testHtmlFileAndConsoleOutput()
+    {
+        $dir = sys_get_temp_dir() . '/deverr_' . uniqid();
+        mkdir($dir);
+        $stream = fopen('php://memory', 'w+');
+        $mw = new DevelopmentErrorMiddleware($dir, true, $stream);
+        $mw->handle(new Exception('boom'));
+        $files = glob($dir . '/*.html');
+        $this->assertCount(1, $files);
+        $content = file_get_contents($files[0]);
+        $this->assertStringContainsString('boom', $content);
+        rewind($stream);
+        $output = stream_get_contents($stream);
+        $this->assertStringContainsString('boom', $output);
+        array_map('unlink', $files);
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary
- create `DevelopmentErrorMiddleware` that writes uncaught exceptions to HTML files
- ensure optional console output
- add PHPUnit test verifying HTML output and console write

## Testing
- `php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cde335a8832c9a14c752d049f368