### PR TITLE
Support flexible schema column definitions

### DIFF
--- a/DBAL/SchemaTableBuilder.php
+++ b/DBAL/SchemaTableBuilder.php
@@ -17,18 +17,26 @@ class SchemaTableBuilder
         $this->create = $create;
     }
 
-    public function column(string $name, string $type): self
+    public function column(string $name, string $type = null): self
     {
         if ($this->create) {
-            $this->definitions[] = sprintf('%s %s', $name, $type);
+            if ($type === null) {
+                $this->definitions[] = $name;
+            } else {
+                $this->definitions[] = sprintf('%s %s', $name, $type);
+            }
         }
         return $this;
     }
 
-    public function addColumn(string $name, string $type): self
+    public function addColumn(string $name, string $type = null): self
     {
         if (!$this->create) {
-            $this->definitions[] = sprintf('ADD COLUMN %s %s', $name, $type);
+            if ($type === null) {
+                $this->definitions[] = sprintf('ADD COLUMN %s', $name);
+            } else {
+                $this->definitions[] = sprintf('ADD COLUMN %s %s', $name, $type);
+            }
         }
         return $this;
     }

--- a/README.md
+++ b/README.md
@@ -327,12 +327,12 @@ $crud = (new DBAL\Crud($pdo))
     ->withMiddleware($schema);
 
 $crud->createTable('items')
-    ->column('id INTEGER PRIMARY KEY AUTOINCREMENT')
-    ->column('name TEXT')
+    ->column('id', 'INTEGER PRIMARY KEY AUTOINCREMENT')
+    ->column('name', 'TEXT')
     ->execute();
 
 $crud->alterTable('items')
-    ->addColumn('price REAL')
+    ->addColumn('price', 'REAL')
     ->execute();
 ```
 

--- a/tests/SchemaMiddlewareTest.php
+++ b/tests/SchemaMiddlewareTest.php
@@ -17,14 +17,14 @@ class SchemaMiddlewareTest extends TestCase
         $crud = (new Crud($pdo))->withMiddleware($schema);
 
         $crud->createTable('items')
-            ->column('id INTEGER PRIMARY KEY AUTOINCREMENT')
-            ->column('name TEXT')
+            ->column('id', 'INTEGER PRIMARY KEY AUTOINCREMENT')
+            ->column('name', 'TEXT')
             ->execute();
 
         $pdo->exec("INSERT INTO items (name) VALUES ('A')");
 
         $crud->alterTable('items')
-            ->addColumn('price INTEGER')
+            ->addColumn('price', 'INTEGER')
             ->execute();
 
         $pdo->exec("INSERT INTO items (name, price) VALUES ('B', 10)");


### PR DESCRIPTION
## Summary
- allow `SchemaTableBuilder::column()` and `addColumn()` to accept either a single definition string or separate name and type arguments
- update README example to demonstrate the new syntax
- adjust schema middleware test for the new API

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d20ef574832c87abb0d68b746760