### PR TITLE
Rename SchemaTableBuilder class

### DIFF
--- a/DBAL/SchemaMiddleware.php
+++ b/DBAL/SchemaMiddleware.php
@@ -18,13 +18,13 @@ class SchemaMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterf
         // no-op
     }
 
-    public function createTable(Crud $crud, string $table): SchemaTableBuilder
+    public function createTable(Crud $crud, string $table): SqlSchemaTableBuilder
     {
-        return new SchemaTableBuilder($this->pdo, $table, true);
+        return new SqlSchemaTableBuilder($this->pdo, $table, true);
     }
 
-    public function alterTable(Crud $crud, string $table): SchemaTableBuilder
+    public function alterTable(Crud $crud, string $table): SqlSchemaTableBuilder
     {
-        return new SchemaTableBuilder($this->pdo, $table, false);
+        return new SqlSchemaTableBuilder($this->pdo, $table, false);
     }
 }

--- a/DBAL/SqlSchemaTableBuilder.php
+++ b/DBAL/SqlSchemaTableBuilder.php
@@ -3,7 +3,7 @@ namespace DBAL;
 
 use PDO;
 
-class SchemaTableBuilder
+class SqlSchemaTableBuilder
 {
     private $pdo;
     private $table;

--- a/README.md
+++ b/README.md
@@ -336,6 +336,9 @@ $crud->alterTable('items')
     ->execute();
 ```
 
+Both `createTable()` and `alterTable()` return an instance of
+`SqlSchemaTableBuilder` used to define the table schema fluently.
+
 ### Development error middleware
 
 `DevelopmentErrorMiddleware` installs an exception handler that displays a basic HTML page whenever an uncaught exception happens. The page supports light and dark themes and allows switching between small, medium and large fonts. When `console` is enabled a text version of the error is written to `STDERR`. If `persistPath` is provided, rendered pages are stored in timestamped folders so they can be reviewed later.

--- a/tests/SchemaMiddlewareTest.php
+++ b/tests/SchemaMiddlewareTest.php
@@ -2,6 +2,7 @@
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\SchemaMiddleware;
+use DBAL\SqlSchemaTableBuilder;
 
 class SchemaMiddlewareTest extends TestCase
 {
@@ -16,10 +17,11 @@ class SchemaMiddlewareTest extends TestCase
         $schema = new SchemaMiddleware($pdo);
         $crud = (new Crud($pdo))->withMiddleware($schema);
 
-        $crud->createTable('items')
-            ->column('id INTEGER PRIMARY KEY AUTOINCREMENT')
-            ->column('name TEXT')
-            ->execute();
+        $builder = $crud->createTable('items');
+        $this->assertInstanceOf(SqlSchemaTableBuilder::class, $builder);
+        $builder->column('id INTEGER PRIMARY KEY AUTOINCREMENT')
+                ->column('name TEXT')
+                ->execute();
 
         $pdo->exec("INSERT INTO items (name) VALUES ('A')");
 


### PR DESCRIPTION
## Summary
- rename DBAL\SchemaTableBuilder to DBAL\SqlSchemaTableBuilder
- update SchemaMiddleware to use the new class
- mention SqlSchemaTableBuilder in the docs
- adjust SchemaMiddlewareTest to assert the return type

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d2141854832cb70e79ea0a536eb4