### PR TITLE
Validate local key before relation load

### DIFF
--- a/DBAL/ResultGenerator.php
+++ b/DBAL/ResultGenerator.php
@@ -38,6 +38,13 @@ class ResultGenerator
             if (!in_array($name, $this->eagerRelations)) {
                 $pdo = $this->pdo;
                 $middlewares = $this->middlewares;
+                if (!array_key_exists($rel['localKey'], $row)) {
+                    throw new \RuntimeException(sprintf(
+                        'Missing local key %s for relation %s',
+                        $rel['localKey'],
+                        $name
+                    ));
+                }
                 $value = $row[$rel['localKey']];
                 $loader = function () use ($pdo, $middlewares, $rel, $value) {
                     $crud = new Crud($pdo);

--- a/DBAL/ResultIterator.php
+++ b/DBAL/ResultIterator.php
@@ -72,6 +72,13 @@ class ResultIterator implements \Iterator, \JsonSerializable
                         if (!in_array($name, $this->eagerRelations)) {
                                 $pdo = $this->pdo;
                                 $middlewares = $this->middlewares;
+                                if (!array_key_exists($rel['localKey'], $result)) {
+                                        throw new \RuntimeException(sprintf(
+                                                'Missing local key %s for relation %s',
+                                                $rel['localKey'],
+                                                $name
+                                        ));
+                                }
                                 $value = $result[$rel['localKey']];
                                 $loader = function () use ($pdo, $middlewares, $rel, $value) {
                                         $crud = new Crud($pdo);

--- a/tests/RelationLoaderMiddlewareTest.php
+++ b/tests/RelationLoaderMiddlewareTest.php
@@ -101,4 +101,36 @@ class RelationLoaderMiddlewareTest extends TestCase
         $this->assertEquals('Alice', $user['name']);
         $this->assertStringContainsString('FROM users', $log[1]);
     }
+
+    public function testMissingLocalKeyThrowsException()
+    {
+        $pdo = $this->createPdo();
+
+        $rel = (new RelationLoaderMiddleware())
+            ->table('profiles')
+            ->belongsTo('user', 'users', 'user_id', 'id');
+
+        $crud = (new Crud($pdo))
+            ->from('profiles')
+            ->withMiddleware($rel);
+
+        $this->expectException(RuntimeException::class);
+        iterator_to_array($crud->select('bio'));
+    }
+
+    public function testMissingLocalKeyThrowsExceptionInStream()
+    {
+        $pdo = $this->createPdo();
+
+        $rel = (new RelationLoaderMiddleware())
+            ->table('profiles')
+            ->belongsTo('user', 'users', 'user_id', 'id');
+
+        $crud = (new Crud($pdo))
+            ->from('profiles')
+            ->withMiddleware($rel);
+
+        $this->expectException(RuntimeException::class);
+        iterator_to_array($crud->stream('bio'));
+    }
 }


### PR DESCRIPTION
## Summary
- ensure lazy relation loaders check for the local key
- throw a RuntimeException when the key is missing
- test missing local key handling for select() and stream()

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d21af278832c93565d44e244d141