### PR TITLE
Define isEmpty property on NotImplementedNode

### DIFF
--- a/DBAL/QueryBuilder/Node/NotImplementedNode.php
+++ b/DBAL/QueryBuilder/Node/NotImplementedNode.php
@@ -3,10 +3,11 @@ namespace DBAL\QueryBuilder\Node;
 
 abstract class NotImplementedNode implements NodeInterface
 {
-	public function appendChild(NodeInterface $node, $name = null)
-	{
-		return $name;
-	}
+        protected $isEmpty = true;
+        public function appendChild(NodeInterface $node, $name = null)
+        {
+                return $name;
+        }
 	public function hasChild($name)
 	{
 		return false;


### PR DESCRIPTION
## Summary
- ensure `NotImplementedNode` declares `$isEmpty`

## Testing
- `php` and `composer` not available, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_6866d2200bbc832cb12dd1d2f36cc8a1