### PR TITLE
Add ABM events middleware

### DIFF
--- a/DBAL/AbmEventInterface.php
+++ b/DBAL/AbmEventInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace DBAL;
+
+interface AbmEventInterface extends MiddlewareInterface
+{
+    public function afterInsert(string $table, array $fields, $id): void;
+    public function afterBulkInsert(string $table, array $rows, int $count): void;
+    public function afterUpdate(string $table, array $fields, int $count): void;
+    public function afterDelete(string $table, int $count): void;
+}

--- a/DBAL/AbmEventMiddleware.php
+++ b/DBAL/AbmEventMiddleware.php
@@ -1,0 +1,57 @@
+<?php
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+class AbmEventMiddleware implements AbmEventInterface
+{
+    private $onInsert;
+    private $onBulkInsert;
+    private $onUpdate;
+    private $onDelete;
+
+    public function __construct(
+        callable $onInsert = null,
+        callable $onUpdate = null,
+        callable $onDelete = null,
+        callable $onBulkInsert = null
+    ) {
+        $this->onInsert = $onInsert;
+        $this->onUpdate = $onUpdate;
+        $this->onDelete = $onDelete;
+        $this->onBulkInsert = $onBulkInsert;
+    }
+
+    public function __invoke(MessageInterface $msg): void
+    {
+        // no-op
+    }
+
+    public function afterInsert(string $table, array $fields, $id): void
+    {
+        if ($this->onInsert) {
+            ($this->onInsert)($table, $fields, $id);
+        }
+    }
+
+    public function afterBulkInsert(string $table, array $rows, int $count): void
+    {
+        if ($this->onBulkInsert) {
+            ($this->onBulkInsert)($table, $rows, $count);
+        }
+    }
+
+    public function afterUpdate(string $table, array $fields, int $count): void
+    {
+        if ($this->onUpdate) {
+            ($this->onUpdate)($table, $fields, $count);
+        }
+    }
+
+    public function afterDelete(string $table, int $count): void
+    {
+        if ($this->onDelete) {
+            ($this->onDelete)($table, $count);
+        }
+    }
+}

--- a/tests/AbmEventMiddlewareTest.php
+++ b/tests/AbmEventMiddlewareTest.php
@@ -1,0 +1,39 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\AbmEventMiddleware;
+
+class AbmEventMiddlewareTest extends TestCase
+{
+    private function createPdo()
+    {
+        return new PDO('sqlite::memory:');
+    }
+
+    public function testCallbacksAreInvoked()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+
+        $events = [];
+        $mw = new AbmEventMiddleware(
+            function ($t, $fields, $id) use (&$events) { $events[] = ['insert', $t, $fields, $id]; },
+            function ($t, $fields, $count) use (&$events) { $events[] = ['update', $t, $fields, $count]; },
+            function ($t, $count) use (&$events) { $events[] = ['delete', $t, $count]; },
+            function ($t, $rows, $count) use (&$events) { $events[] = ['bulk', $t, $rows, $count]; }
+        );
+
+        $crud = (new Crud($pdo))->from('test')->withMiddleware($mw);
+
+        $id = $crud->insert(['name' => 'A']);
+        $crud->bulkInsert([['name' => 'B']]);
+        $crud->where(['id__eq' => $id])->update(['name' => 'C']);
+        $crud->where(['id__eq' => $id])->delete();
+
+        $this->assertCount(4, $events);
+        $this->assertEquals('insert', $events[0][0]);
+        $this->assertEquals('bulk', $events[1][0]);
+        $this->assertEquals('update', $events[2][0]);
+        $this->assertEquals('delete', $events[3][0]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `AbmEventInterface` and `AbmEventMiddleware`
- notify middleware callbacks from `Crud` after inserts, updates, deletes and bulk inserts
- test new middleware

## Testing
- `phpunit -c phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d5964f1c832c990ae5612d1b9672