### PR TITLE
Improve docs and add documentation folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # DBAL
 
 A lightweight Database Abstraction Layer for PHP.
+## What's New
+- ActiveRecord support with dynamic properties
+- Caching middleware with pluggable storage
+- Transaction and Unit of Work middlewares
+- ABM event hooks to listen for inserts, updates or deletes
+- Improved documentation and error pages
 
 ## Installation
 
@@ -351,3 +357,33 @@ $errors = new DBAL\DevelopmentErrorMiddleware([
 $crud = (new DBAL\Crud($pdo))
     ->withMiddleware($errors);
 ```
+
+### Cache middleware
+
+`CacheMiddleware` stores the result of SELECT statements and invalidates the cache when data changes. The package includes in-memory and SQLite storage adapters.
+
+### Active record
+
+`ActiveRecordMiddleware` decorates rows with an object capable of tracking modified fields. Calling `$record->update()` only persists changes.
+
+### Transaction and unit of work
+
+`TransactionMiddleware` exposes helpers to start, commit or roll back transactions. `UnitOfWorkMiddleware` batches multiple operations and applies them atomically via `commit()`.  
+
+### ABM event middleware
+
+`AbmEventMiddleware` lets you execute callbacks after inserts, bulk inserts, updates or deletes to implement custom hooks.
+
+## Practical use cases
+
+- **Online book stores**: manage books and orders with validation and caching.
+- **Cinema ticketing**: control screenings and seat reservations with transactional safety.
+- **Logistics microservices**: build lightweight APIs that share filters and schemas across services.
+
+DBAL integrates easily with minimal frameworks like Slim and Lumen or even plain PHP scripts. Additional examples and API reference can be found in the [docs](docs/) folder.
+
+## Expanding DBAL
+
+Middlewares are simple classes that implement `MiddlewareInterface`. Create your own to add behaviours such as auditing or soft deletes and attach them with `withMiddleware()`.
+
+

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,14 @@
+# Practical Use Cases
+
+Below are some scenarios where DBAL can simplify data access.
+
+## Online Book Store
+Use `Crud` to handle products and orders while middlewares provide validation and caching. Relations allow lazy loading of author data.
+
+## Cinema Ticketing
+Manage screenings and seat reservations with transactions and unit of work to ensure consistency.
+
+## Logistics API in Microservices
+Combine DBAL with Slim or Lumen to create lightweight services that read and write package data. Global filters can enforce multi-tenant restrictions across all queries.
+
+

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,36 @@
+# Using DBAL with Other Frameworks
+
+DBAL is framework agnostic and can be used alongside popular minimalistic frameworks or in plain PHP scripts.
+
+## Slim Framework
+```php
+use Psr\Container\ContainerInterface;
+use DBAL\Crud;
+
+return function (ContainerInterface $c) {
+    $pdo = $c->get('pdo');
+    return (new Crud($pdo))->from('books');
+};
+```
+
+## Lumen
+```php
+$router->get('/books', function () {
+    $pdo = app('db')->connection()->getPdo();
+    $crud = (new DBAL\Crud($pdo))->from('books');
+    return response()->json(iterator_to_array($crud->select()));
+});
+```
+
+## Plain PHP
+```php
+$pdo = new PDO('sqlite:app.db');
+$books = (new DBAL\Crud($pdo))->from('books')->select();
+foreach ($books as $book) {
+    echo $book['title'];
+}
+```
+
+DBAL fits naturally into any existing project thanks to its single dependency on PDO.
+
+

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -1,0 +1,39 @@
+# Built-in Middlewares
+
+DBAL ships with several optional middlewares that can be attached to a `Crud` instance.
+
+## ActiveRecordMiddleware
+Provides `ActiveRecord` objects with dynamic getters and setters. Use `$record->update()` to persist modified fields.
+
+## CacheMiddleware
+Caches SELECT query results using an in-memory or custom storage. Results are invalidated when insert, update or delete statements run.
+
+## TransactionMiddleware
+Wraps operations inside database transactions and exposes `begin()`, `commit()` and `rollback()` helpers.
+
+## UnitOfWorkMiddleware
+Registers new, dirty and deleted entities and persists them in a single transaction via `commit()`.
+
+## AbmEventMiddleware
+Allows executing callbacks after insert, bulk insert, update or delete operations.
+
+## FirstLastMiddleware
+Adds `first()`, `firstOrDefault()`, `last()` and `lastOrDefault()` to quickly fetch a single row.
+
+## LinqMiddleware
+Adds `any()` and `all()` methods for boolean existence checks.
+
+## EntityValidationMiddleware
+Provides a fluent API to validate data and declare relations for eager or lazy loading.
+
+## GlobalFilterMiddleware
+Appends extra filters automatically to every SELECT statement.
+
+## SchemaMiddleware
+Creates or alters tables through a fluent schema builder.
+
+## DevelopmentErrorMiddleware
+Shows a detailed HTML page when an uncaught exception happens during development.
+
+Each middleware implements `MiddlewareInterface` and can be combined freely.
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,9 @@
+# DBAL Documentation
+
+This folder contains extended documentation for the DBAL library.
+
+* **overview.md** – this file, quick introduction and benefits.
+* **middlewares.md** – explanation of included middlewares and how to extend them.
+* **integration.md** – examples of integrating DBAL with frameworks such as Slim and Lumen or plain PHP.
+* **examples.md** – practical use cases for book stores, cinemas and logistic APIs.
+


### PR DESCRIPTION
## Summary
- document new features at the top of `README.md`
- add sections describing cache, active record, transaction, unit of work and event middlewares
- list practical use cases and link to new `docs` folder
- add a `docs` folder with guides on built-in middlewares, integration and examples

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6866d8e96adc832cb1296eab642ce66d