### PR TITLE
Update PHP version requirement

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.1'
+
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "php": ">=7.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9"


### PR DESCRIPTION
## Summary
- require PHP 8.1 in `composer.json`
- add a setup step for PHP 8.1 in GitHub Actions workflow

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866db855d78832c9306bd4e4cd8dad3