### PR TITLE
Add typed properties and constructor promotion

### DIFF
--- a/DBAL/AbmEventMiddleware.php
+++ b/DBAL/AbmEventMiddleware.php
@@ -8,25 +8,12 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class AbmEventMiddleware implements AbmEventInterface
 {
-/** @var mixed */
-    private $onInsert;
-/** @var mixed */
-    private $onBulkInsert;
-/** @var mixed */
-    private $onUpdate;
-/** @var mixed */
-    private $onDelete;
-
     public function __construct(
-        callable $onInsert = null,
-        callable $onUpdate = null,
-        callable $onDelete = null,
-        callable $onBulkInsert = null
+        private ?callable $onInsert = null,
+        private ?callable $onUpdate = null,
+        private ?callable $onDelete = null,
+        private ?callable $onBulkInsert = null
     ) {
-        $this->onInsert = $onInsert;
-        $this->onUpdate = $onUpdate;
-        $this->onDelete = $onDelete;
-        $this->onBulkInsert = $onBulkInsert;
     }
 
 /**

--- a/DBAL/ActiveRecord.php
+++ b/DBAL/ActiveRecord.php
@@ -6,24 +6,20 @@ namespace DBAL;
  */
 class ActiveRecord implements \JsonSerializable
 {
-/** @var mixed */
-        private $crud;
-/** @var mixed */
-        private $original = [];
-/** @var mixed */
-        private $modified = [];
+        private Crud $crud;
+        private array $original = [];
+        private array $modified = [];
 
 /**
  * __construct
  * @param Crud $crud
- * @param array $data
+ * @param array $original
  * @return void
  */
 
-        public function __construct(Crud $crud, array $data)
+        public function __construct(private Crud $crud, array $original)
         {
-                $this->crud = $crud;
-                $this->original = $data;
+                $this->original = $original;
         }
 
 /**

--- a/DBAL/Crud.php
+++ b/DBAL/Crud.php
@@ -12,25 +12,19 @@ use Generator;
  */
 class Crud extends Query
 {
-/** @var mixed */
-        protected $connection;
-/** @var mixed */
-        protected $mappers = [];
-/** @var mixed */
-        protected $middlewares = [];
-/** @var mixed */
-        protected $tables = [];
-/** @var mixed */
-        protected $with = [];
+        protected \PDO $connection;
+        protected array $mappers = [];
+        protected array $middlewares = [];
+        protected array $tables = [];
+        protected array $with = [];
 /**
  * __construct
  * @param \PDO $connection
  * @return void
  */
 
-        public function __construct(\PDO $connection)
+        public function __construct(protected \PDO $connection)
         {
-                $this->connection = $connection;
                 parent::__construct();
         }
 /**

--- a/DBAL/DevelopmentErrorMiddleware.php
+++ b/DBAL/DevelopmentErrorMiddleware.php
@@ -8,14 +8,10 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class DevelopmentErrorMiddleware implements MiddlewareInterface
 {
-/** @var mixed */
-    private $console;
-/** @var mixed */
-    private $persistPath;
-/** @var mixed */
-    private $theme;
-/** @var mixed */
-    private $fontSize;
+    private bool $console;
+    private ?string $persistPath;
+    private string $theme;
+    private string $fontSize;
 
 /**
  * __construct

--- a/DBAL/EntityValidationMiddleware.php
+++ b/DBAL/EntityValidationMiddleware.php
@@ -10,15 +10,11 @@ use DBAL\RelationDefinition;
  */
 class EntityValidationMiddleware implements EntityValidationInterface
 {
-/** @var mixed */
-    private $rules = [];
-/** @var mixed */
-    private $relations = [];
+    private array $rules = [];
+    private array $relations = [];
 
-/** @var mixed */
-    private $currentTable;
-/** @var mixed */
-    private $currentField;
+    private string $currentTable;
+    private string $currentField;
 
 /**
  * __invoke

--- a/DBAL/FirstLastMiddleware.php
+++ b/DBAL/FirstLastMiddleware.php
@@ -8,8 +8,7 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class FirstLastMiddleware implements MiddlewareInterface
 {
-/** @var mixed */
-    private $crud;
+    private Crud $crud;
 
 /**
  * __invoke

--- a/DBAL/GlobalFilterMiddleware.php
+++ b/DBAL/GlobalFilterMiddleware.php
@@ -9,10 +9,8 @@ use DBAL\QueryBuilder\Message;
  */
 class GlobalFilterMiddleware implements MiddlewareInterface
 {
-/** @var mixed */
-    private $tableFilters = [];
-/** @var mixed */
-    private $globalFilters = [];
+    private array $tableFilters = [];
+    private array $globalFilters = [];
 
 /**
  * __construct

--- a/DBAL/LazyRelation.php
+++ b/DBAL/LazyRelation.php
@@ -10,12 +10,8 @@ use JsonSerializable;
  */
 class LazyRelation implements IteratorAggregate, JsonSerializable
 {
-/** @var mixed */
-    private $loader;
-/** @var mixed */
-    private $loaded = false;
-/** @var mixed */
-    private $data;
+    private bool $loaded = false;
+    private mixed $data;
 
 /**
  * __construct
@@ -23,9 +19,8 @@ class LazyRelation implements IteratorAggregate, JsonSerializable
  * @return void
  */
 
-    public function __construct(callable $loader)
+    public function __construct(private callable $loader)
     {
-        $this->loader = $loader;
     }
 
 /**

--- a/DBAL/MemoryCacheStorage.php
+++ b/DBAL/MemoryCacheStorage.php
@@ -6,8 +6,7 @@ namespace DBAL;
  */
 class MemoryCacheStorage implements CacheStorageInterface
 {
-/** @var mixed */
-    private $data = [];
+    private array $data = [];
 
 /**
  * get

--- a/DBAL/QueryBuilder/DynamicFilterBuilder.php
+++ b/DBAL/QueryBuilder/DynamicFilterBuilder.php
@@ -9,10 +9,8 @@ use DBAL\QueryBuilder\Node\FilterNode;
  */
 class DynamicFilterBuilder
 {
-/** @var mixed */
-       protected $stack = [];
-/** @var mixed */
-       protected $nextOperator = MessageInterface::SEPARATOR_AND;
+       protected array $stack = [];
+       protected string $nextOperator = MessageInterface::SEPARATOR_AND;
 
 /**
  * __construct

--- a/DBAL/QueryBuilder/Message.php
+++ b/DBAL/QueryBuilder/Message.php
@@ -6,12 +6,9 @@ namespace DBAL\QueryBuilder;
  */
 class Message implements MessageInterface
 {
-/** @var mixed */
-	protected $type;
-/** @var mixed */
-	protected $message;
-/** @var mixed */
-	protected $values;
+        protected int $type;
+        protected string $message;
+        protected array $values;
 /**
  * __construct
  * @param mixed $type

--- a/DBAL/QueryBuilder/Node/ChangeNode.php
+++ b/DBAL/QueryBuilder/Node/ChangeNode.php
@@ -10,11 +10,9 @@ use DBAL\QueryBuilder\Message;
 class ChangeNode extends NotImplementedNode
 {
 /** @var mixed */
-        protected $isEmpty = false;
-/** @var mixed */
-        protected $fields = [];
-/** @var mixed */
-        protected $rows = null;
+        protected bool $isEmpty = false;
+        protected array $fields = [];
+        protected ?array $rows = null;
 /**
  * setFields
  * @param array $fields

--- a/DBAL/QueryBuilder/Node/EmptyNode.php
+++ b/DBAL/QueryBuilder/Node/EmptyNode.php
@@ -8,8 +8,7 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class EmptyNode extends NotImplementedNode
 {
-/** @var mixed */
-	protected $isEmpty = true;
+        protected bool $isEmpty = true;
 /**
  * send
  * @param MessageInterface $message

--- a/DBAL/QueryBuilder/Node/FieldNode.php
+++ b/DBAL/QueryBuilder/Node/FieldNode.php
@@ -8,10 +8,8 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class FieldNode extends NotImplementedNode
 {
-/** @var mixed */
-	protected $isEmpty = false;
-/** @var mixed */
-	protected $field;
+        protected bool $isEmpty = false;
+        protected mixed $field;
 /**
  * __construct
  * @param mixed $field

--- a/DBAL/QueryBuilder/Node/FieldsNode.php
+++ b/DBAL/QueryBuilder/Node/FieldsNode.php
@@ -10,8 +10,7 @@ use DBAL\QueryBuilder\Node\NodeInterface;
  */
 class FieldsNode extends Node
 {
-/** @var mixed */
-	protected $isEmpty = false;
+        protected bool $isEmpty = false;
 /**
  * send
  * @param MessageInterface $message

--- a/DBAL/QueryBuilder/Node/FilterNode.php
+++ b/DBAL/QueryBuilder/Node/FilterNode.php
@@ -9,13 +9,10 @@ use DBAL\QueryBuilder\Message;
  */
 class FilterNode extends Node
 {
-        protected static $filters = [];
-/** @var mixed */
-        protected $isEmpty = false;
-/** @var mixed */
-        protected $parts;
-/** @var mixed */
-        protected $operator;
+        protected static array $filters = [];
+        protected bool $isEmpty = false;
+        protected array $parts;
+        protected string $operator;
 /**
  * __construct
  * @param array $parts

--- a/DBAL/QueryBuilder/Node/GroupNode.php
+++ b/DBAL/QueryBuilder/Node/GroupNode.php
@@ -10,8 +10,7 @@ use DBAL\QueryBuilder\Node\NodeInterface;
  */
 class GroupNode extends Node
 {
-/** @var mixed */
-	protected $isEmpty = false;
+        protected bool $isEmpty = false;
 /**
  * send
  * @param MessageInterface $message

--- a/DBAL/QueryBuilder/Node/HavingNode.php
+++ b/DBAL/QueryBuilder/Node/HavingNode.php
@@ -10,8 +10,7 @@ use DBAL\QueryBuilder\Node\NodeInterface;
  */
 class HavingNode extends Node
 {
-/** @var mixed */
-	protected $isEmpty = false;
+        protected bool $isEmpty = false;
 /**
  * send
  * @param MessageInterface $message

--- a/DBAL/QueryBuilder/Node/JoinNode.php
+++ b/DBAL/QueryBuilder/Node/JoinNode.php
@@ -9,17 +9,13 @@ use DBAL\QueryBuilder\Message;
  */
 class JoinNode extends NotImplementedNode
 {
-	const INNER_JOIN = 'INNER JOIN';
-	const LEFT_JOIN = 'LEFT JOIN';
-	const RIGHT_JOIN = 'RIGHT JOIN';
-/** @var mixed */
-	protected $isEmpty = false;
-/** @var mixed */
-	protected $table;
-/** @var mixed */
-	protected $type;
-/** @var mixed */
-	protected $on = [];
+        const INNER_JOIN = 'INNER JOIN';
+        const LEFT_JOIN = 'LEFT JOIN';
+        const RIGHT_JOIN = 'RIGHT JOIN';
+        protected bool $isEmpty = false;
+        protected string $table;
+        protected string $type;
+        protected array $on = [];
 /**
  * __construct
  * @param mixed $table

--- a/DBAL/QueryBuilder/Node/JoinsNode.php
+++ b/DBAL/QueryBuilder/Node/JoinsNode.php
@@ -10,8 +10,7 @@ use DBAL\QueryBuilder\Node\NodeInterface;
  */
 class JoinsNode extends Node
 {
-/** @var mixed */
-	protected $isEmpty = false;
+        protected bool $isEmpty = false;
 /**
  * send
  * @param MessageInterface $message

--- a/DBAL/QueryBuilder/Node/LimitNode.php
+++ b/DBAL/QueryBuilder/Node/LimitNode.php
@@ -8,12 +8,9 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class LimitNode extends NotImplementedNode
 {
-/** @var mixed */
-	protected $isEmpty = false;
-/** @var mixed */
-	protected $limit = null;
-/** @var mixed */
-	protected $offset = null;
+        protected bool $isEmpty = false;
+        protected ?int $limit = null;
+        protected ?int $offset = null;
 /**
  * setLimit
  * @param mixed $limit

--- a/DBAL/QueryBuilder/Node/Node.php
+++ b/DBAL/QueryBuilder/Node/Node.php
@@ -6,10 +6,8 @@ namespace DBAL\QueryBuilder\Node;
  */
 abstract class Node implements NodeInterface
 {
-/** @var mixed */
-	protected $isEmpty;
-/** @var mixed */
-	protected $childs = [];
+        protected bool $isEmpty;
+        protected array $childs = [];
 /**
  * appendChild
  * @param NodeInterface $node

--- a/DBAL/QueryBuilder/Node/NotImplementedNode.php
+++ b/DBAL/QueryBuilder/Node/NotImplementedNode.php
@@ -6,8 +6,7 @@ namespace DBAL\QueryBuilder\Node;
  */
 abstract class NotImplementedNode implements NodeInterface
 {
-/** @var mixed */
-        protected $isEmpty = true;
+        protected bool $isEmpty = true;
 /**
  * appendChild
  * @param NodeInterface $node

--- a/DBAL/QueryBuilder/Node/OrderNode.php
+++ b/DBAL/QueryBuilder/Node/OrderNode.php
@@ -10,10 +10,9 @@ use DBAL\QueryBuilder\Node\NodeInterface;
  */
 class OrderNode extends Node
 {
-	const ORDER_DESC = 'DESC';
-	const ORDER_ASC = 'ASC';
-/** @var mixed */
-	protected $isEmpty = false;
+        const ORDER_DESC = 'DESC';
+        const ORDER_ASC = 'ASC';
+        protected bool $isEmpty = false;
 /**
  * send
  * @param MessageInterface $message

--- a/DBAL/QueryBuilder/Node/QueryNode.php
+++ b/DBAL/QueryBuilder/Node/QueryNode.php
@@ -10,8 +10,7 @@ use DBAL\QueryBuilder\NodeInterface;
  */
 class QueryNode extends Node
 {
-/** @var mixed */
-	protected $isEmpty = false;
+        protected bool $isEmpty = false;
 /**
  * __construct
  * @return void

--- a/DBAL/QueryBuilder/Node/TableNode.php
+++ b/DBAL/QueryBuilder/Node/TableNode.php
@@ -8,20 +8,16 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class TableNode extends NotImplementedNode
 {
-/** @var mixed */
-	protected $isEmpty = false;
-/** @var mixed */
-	protected $table;
+        protected bool $isEmpty = false;
 /**
  * __construct
  * @param mixed $table
  * @return void
  */
 
-	public function __construct($table)
-	{
-		$this->table = $table;
-	}
+        public function __construct(private mixed $table)
+        {
+        }
 /**
  * send
  * @param MessageInterface $message

--- a/DBAL/QueryBuilder/Node/TablesNode.php
+++ b/DBAL/QueryBuilder/Node/TablesNode.php
@@ -10,8 +10,7 @@ use DBAL\QueryBuilder\Node\NodeInterface;
  */
 class TablesNode extends Node
 {
-/** @var mixed */
-	protected $isEmpty = false;
+        protected bool $isEmpty = false;
 /**
  * send
  * @param MessageInterface $message

--- a/DBAL/QueryBuilder/Node/WhereNode.php
+++ b/DBAL/QueryBuilder/Node/WhereNode.php
@@ -10,8 +10,7 @@ use DBAL\QueryBuilder\Node\NodeInterface;
  */
 class WhereNode extends Node
 {
-/** @var mixed */
-	protected $isEmpty = false;
+        protected bool $isEmpty = false;
 /**
  * send
  * @param MessageInterface $message

--- a/DBAL/RelationDefinition.php
+++ b/DBAL/RelationDefinition.php
@@ -6,14 +6,10 @@ namespace DBAL;
  */
 class RelationDefinition
 {
-/** @var mixed */
-    private $name;
-/** @var mixed */
-    private $table;
-/** @var mixed */
-    private $type;
-/** @var mixed */
-    private $conditions = [];
+    private string $name;
+    private string $table;
+    private string $type;
+    private array $conditions = [];
 
 /**
  * __construct
@@ -21,10 +17,8 @@ class RelationDefinition
  * @return void
  */
 
-    public function __construct(string $name)
-    {
-        $this->name = $name;
-    }
+    public function __construct(private string $name)
+    {    }
 
 /**
  * hasOne

--- a/DBAL/RelationLoaderMiddleware.php
+++ b/DBAL/RelationLoaderMiddleware.php
@@ -8,10 +8,8 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class RelationLoaderMiddleware implements MiddlewareInterface
 {
-/** @var mixed */
-    private $currentTable;
-/** @var mixed */
-    private $relations = [];
+    private string $currentTable;
+    private array $relations = [];
 
 /**
  * __invoke

--- a/DBAL/ResultGenerator.php
+++ b/DBAL/ResultGenerator.php
@@ -10,18 +10,12 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class ResultGenerator
 {
-/** @var mixed */
-    private $pdo;
-/** @var mixed */
-    private $message;
-/** @var mixed */
-    private $mappers;
-/** @var mixed */
-    private $middlewares;
-/** @var mixed */
-    private $relations;
-/** @var mixed */
-    private $eagerRelations;
+    private PDO $pdo;
+    private MessageInterface $message;
+    private array $mappers;
+    private array $middlewares;
+    private array $relations;
+    private array $eagerRelations;
 
 /**
  * __construct
@@ -34,14 +28,14 @@ class ResultGenerator
  * @return void
  */
 
-    public function __construct(PDO $pdo, MessageInterface $message, array $mappers = [], array $middlewares = [], array $relations = [], array $eagerRelations = [])
-    {
-        $this->pdo = $pdo;
-        $this->message = $message;
-        $this->mappers = $mappers;
-        $this->middlewares = $middlewares;
-        $this->relations = $relations;
-        $this->eagerRelations = $eagerRelations;
+    public function __construct(
+        private PDO $pdo,
+        private MessageInterface $message,
+        private array $mappers = [],
+        private array $middlewares = [],
+        private array $relations = [],
+        private array $eagerRelations = []
+    ) {
     }
 
 /**

--- a/DBAL/ResultIterator.php
+++ b/DBAL/ResultIterator.php
@@ -8,26 +8,16 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class ResultIterator implements \Iterator, \JsonSerializable
 {
-/** @var mixed */
-        protected $pdo;
-/** @var mixed */
-        protected $message;
-/** @var mixed */
-        protected $result;
-/** @var mixed */
-        protected $i;
-/** @var mixed */
-        protected $stm;
-/** @var mixed */
-        protected $rows = [];
-/** @var mixed */
-        protected $mappers;
-/** @var mixed */
-        protected $middlewares;
-/** @var mixed */
-        protected $relations;
-/** @var mixed */
-        protected $eagerRelations;
+        protected \PDO $pdo;
+        protected MessageInterface $message;
+        protected mixed $result;
+        protected int $i;
+        protected ?\PDOStatement $stm;
+        protected array $rows = [];
+        protected array $mappers;
+        protected array $middlewares;
+        protected array $relations;
+        protected array $eagerRelations;
 /**
  * __construct
  * @param \PDO $pdo
@@ -39,14 +29,15 @@ class ResultIterator implements \Iterator, \JsonSerializable
  * @return void
  */
 
-        public function __construct(\PDO $pdo, MessageInterface $message, array $mappers = [], array $middlewares = [], array $relations = [], array $eagerRelations = [])
-        {
-                $this->pdo = $pdo;
-                $this->message = $message;
-                $this->mappers = $mappers;
-                $this->middlewares = $middlewares;
-                $this->relations = $relations;
-                $this->eagerRelations = $eagerRelations;
+        public function __construct(
+                protected \PDO $pdo,
+                protected MessageInterface $message,
+                protected array $mappers = [],
+                protected array $middlewares = [],
+                protected array $relations = [],
+                protected array $eagerRelations = []
+        ) {
+                $this->i = 0;
         }
 /**
  * rewind

--- a/DBAL/Schema/SchemaColumnBuilder.php
+++ b/DBAL/Schema/SchemaColumnBuilder.php
@@ -6,12 +6,9 @@ namespace DBAL\Schema;
  */
 class SchemaColumnBuilder
 {
-/** @var mixed */
-    private $name;
-/** @var mixed */
-    private $type = '';
-/** @var mixed */
-    private $constraints = [];
+    private string $name;
+    private string $type = '';
+    private array $constraints = [];
 
 /**
  * __construct
@@ -19,10 +16,8 @@ class SchemaColumnBuilder
  * @return void
  */
 
-    public function __construct(string $name)
-    {
-        $this->name = $name;
-    }
+    public function __construct(private string $name)
+    {    }
 
 /**
  * type

--- a/DBAL/Schema/SchemaTableBuilder.php
+++ b/DBAL/Schema/SchemaTableBuilder.php
@@ -6,10 +6,9 @@ namespace DBAL\Schema;
  */
 class SchemaTableBuilder
 {
-/** @var mixed */
-    private $name;
+    private string $name;
     /** @var SchemaColumnBuilder[] */
-    private $columns = [];
+    private array $columns = [];
 
 /**
  * __construct
@@ -17,10 +16,8 @@ class SchemaTableBuilder
  * @return void
  */
 
-    public function __construct(string $name)
-    {
-        $this->name = $name;
-    }
+    public function __construct(private string $name)
+    {    }
 
 /**
  * column

--- a/DBAL/SchemaMiddleware.php
+++ b/DBAL/SchemaMiddleware.php
@@ -9,8 +9,7 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class SchemaMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterface
 {
-/** @var mixed */
-    private $pdo;
+    private PDO $pdo;
 
 /**
  * __construct
@@ -18,9 +17,8 @@ class SchemaMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterf
  * @return void
  */
 
-    public function __construct(PDO $pdo)
+    public function __construct(private PDO $pdo)
     {
-        $this->pdo = $pdo;
     }
 
 /**

--- a/DBAL/SqlSchemaTableBuilder.php
+++ b/DBAL/SqlSchemaTableBuilder.php
@@ -8,14 +8,10 @@ use PDO;
  */
 class SqlSchemaTableBuilder
 {
-/** @var mixed */
-    private $pdo;
-/** @var mixed */
-    private $table;
-/** @var mixed */
-    private $create = true;
-/** @var mixed */
-    private $definitions = [];
+    private PDO $pdo;
+    private string $table;
+    private bool $create = true;
+    private array $definitions = [];
 
 /**
  * __construct
@@ -25,13 +21,9 @@ class SqlSchemaTableBuilder
  * @return void
  */
 
-    public function __construct(PDO $pdo, string $table, bool $create = true)
+    public function __construct(private PDO $pdo, private string $table, private bool $create = true)
     {
-        $this->pdo = $pdo;
-        $this->table = $table;
-        $this->create = $create;
     }
-
 /**
  * column
  * @param string $name

--- a/DBAL/SqliteCacheStorage.php
+++ b/DBAL/SqliteCacheStorage.php
@@ -8,8 +8,7 @@ use PDO;
  */
 class SqliteCacheStorage implements CacheStorageInterface
 {
-/** @var mixed */
-    private $pdo;
+    private PDO $pdo;
 
 /**
  * __construct

--- a/DBAL/TransactionMiddleware.php
+++ b/DBAL/TransactionMiddleware.php
@@ -9,12 +9,9 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class TransactionMiddleware implements MiddlewareInterface
 {
-/** @var mixed */
-    private $pdo;
-/** @var mixed */
-    private $log = [];
-/** @var mixed */
-    private $inTx = false;
+    private PDO $pdo;
+    private array $log = [];
+    private bool $inTx = false;
 
 /**
  * __construct
@@ -22,10 +19,8 @@ class TransactionMiddleware implements MiddlewareInterface
  * @return void
  */
 
-    public function __construct(PDO $pdo)
-    {
-        $this->pdo = $pdo;
-    }
+    public function __construct(private PDO $pdo)
+    {    }
 
 /**
  * __invoke

--- a/DBAL/UnitOfWorkMiddleware.php
+++ b/DBAL/UnitOfWorkMiddleware.php
@@ -9,14 +9,10 @@ use Exception;
  */
 class UnitOfWorkMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterface
 {
-/** @var mixed */
-    private $tx;
-/** @var mixed */
-    private $news = [];
-/** @var mixed */
-    private $dirty = [];
-/** @var mixed */
-    private $delete = [];
+    private TransactionMiddleware $tx;
+    private array $news = [];
+    private array $dirty = [];
+    private array $delete = [];
 
 /**
  * __construct
@@ -24,10 +20,8 @@ class UnitOfWorkMiddleware implements MiddlewareInterface, CrudAwareMiddlewareIn
  * @return void
  */
 
-    public function __construct(TransactionMiddleware $tx)
-    {
-        $this->tx = $tx;
-    }
+    public function __construct(private TransactionMiddleware $tx)
+    {    }
 
 /**
  * __invoke

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "php": ">=7.0"
+        "php": ">=8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9"


### PR DESCRIPTION
## Summary
- add PHP type declarations for class properties
- promote simple constructors using PHP 8 syntax
- require PHP 8 in composer.json

## Testing
- `php vendor/bin/phpunit` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6866db8708a0832c81ccbb1b8837c242