### PR TITLE
Improve OData middleware API

### DIFF
--- a/DBAL/ODataMiddleware.php
+++ b/DBAL/ODataMiddleware.php
@@ -11,10 +11,21 @@ use DBAL\QueryBuilder\Node\FilterNode;
 class ODataMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterface
 {
     private array $selectFields = [];
+    private ?Crud $crud = null;
 
     public function __invoke(MessageInterface $msg): void
     {
         // no-op
+    }
+
+    /**
+     * Attach this middleware to a Crud instance and keep a reference to it.
+     */
+    public function attach(Crud $crud): Crud
+    {
+        $crud = $crud->withMiddleware($this);
+        $this->crud = $crud;
+        return $crud;
     }
 
     /**
@@ -49,6 +60,8 @@ class ODataMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterfa
         }
         if (isset($params['$select'])) {
             $this->selectFields = array_map('trim', explode(',', $params['$select']));
+        } else {
+            $this->selectFields = [];
         }
 
         return $result;
@@ -60,6 +73,20 @@ class ODataMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterfa
     public function getFields(): array
     {
         return $this->selectFields;
+    }
+
+    /**
+     * Apply an OData query string to the attached Crud and return the results.
+     */
+    public function query(string $odata): array
+    {
+        if (!$this->crud) {
+            throw new \LogicException('ODataMiddleware not attached to Crud');
+        }
+
+        $crud = $this->apply($this->crud, $odata);
+        $fields = $this->selectFields;
+        return iterator_to_array($crud->select(...$fields));
     }
 
     private function parseFilter(string $expr): FilterNode


### PR DESCRIPTION
## Summary
- attach Crud instances directly to `ODataMiddleware`
- add `query()` helper to execute an OData string and return rows
- document the new API with an example using an HTTP request path
- clarify in README what the result array looks like for that example

## Testing
- `composer test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6867d8d909e0832caedc88857a7081f0