### PR TITLE
Fix property redeclaration

### DIFF
--- a/DBAL/Crud.php
+++ b/DBAL/Crud.php
@@ -12,7 +12,6 @@ use Generator;
  */
 class Crud extends Query
 {
-        protected \PDO $connection;
         protected array $mappers = [];
         protected array $middlewares = [];
         protected array $tables = [];


### PR DESCRIPTION
## Summary
- remove duplicate `$connection` property definition from `Crud`

## Testing
- `php -v` *(fails: command not found)*
- `composer run-script test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867dfa84b50832c9ab0ce1278c5e7bb