### PR TITLE
Fix property redeclaration in ResultIterator

### DIFF
--- a/DBAL/ResultIterator.php
+++ b/DBAL/ResultIterator.php
@@ -8,16 +8,10 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class ResultIterator implements \Iterator, \JsonSerializable
 {
-        protected \PDO $pdo;
-        protected MessageInterface $message;
         protected mixed $result;
         protected int $i;
         protected ?\PDOStatement $stm;
         protected array $rows = [];
-        protected array $mappers;
-        protected array $middlewares;
-        protected array $relations;
-        protected array $eagerRelations;
 /**
  * __construct
  * @param \PDO $pdo


### PR DESCRIPTION
## Summary
- remove duplicated property declarations
- keep properties only for runtime state

## Testing
- `composer run-script test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867e07916ec832c8ea3ffc0f3c6c3df