### PR TITLE
Remove duplicate promoted property declarations

### DIFF
--- a/DBAL/ActiveRecord.php
+++ b/DBAL/ActiveRecord.php
@@ -6,7 +6,6 @@ namespace DBAL;
  */
 class ActiveRecord implements \JsonSerializable
 {
-        private Crud $crud;
         private array $original = [];
         private array $modified = [];
 

--- a/DBAL/RelationDefinition.php
+++ b/DBAL/RelationDefinition.php
@@ -6,7 +6,6 @@ namespace DBAL;
  */
 class RelationDefinition
 {
-    private string $name;
     private string $table;
     private string $type;
     private array $conditions = [];

--- a/DBAL/ResultGenerator.php
+++ b/DBAL/ResultGenerator.php
@@ -10,12 +10,6 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class ResultGenerator
 {
-    private PDO $pdo;
-    private MessageInterface $message;
-    private array $mappers;
-    private array $middlewares;
-    private array $relations;
-    private array $eagerRelations;
 
 /**
  * __construct

--- a/DBAL/Schema/SchemaColumnBuilder.php
+++ b/DBAL/Schema/SchemaColumnBuilder.php
@@ -6,7 +6,6 @@ namespace DBAL\Schema;
  */
 class SchemaColumnBuilder
 {
-    private string $name;
     private string $type = '';
     private array $constraints = [];
 

--- a/DBAL/Schema/SchemaTableBuilder.php
+++ b/DBAL/Schema/SchemaTableBuilder.php
@@ -6,7 +6,6 @@ namespace DBAL\Schema;
  */
 class SchemaTableBuilder
 {
-    private string $name;
     /** @var SchemaColumnBuilder[] */
     private array $columns = [];
 

--- a/DBAL/SchemaMiddleware.php
+++ b/DBAL/SchemaMiddleware.php
@@ -9,7 +9,6 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class SchemaMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterface
 {
-    private PDO $pdo;
 
 /**
  * __construct

--- a/DBAL/SqlSchemaTableBuilder.php
+++ b/DBAL/SqlSchemaTableBuilder.php
@@ -8,9 +8,6 @@ use PDO;
  */
 class SqlSchemaTableBuilder
 {
-    private PDO $pdo;
-    private string $table;
-    private bool $create = true;
     private array $definitions = [];
 
 /**

--- a/DBAL/TransactionMiddleware.php
+++ b/DBAL/TransactionMiddleware.php
@@ -9,7 +9,6 @@ use DBAL\QueryBuilder\MessageInterface;
  */
 class TransactionMiddleware implements MiddlewareInterface
 {
-    private PDO $pdo;
     private array $log = [];
     private bool $inTx = false;
 

--- a/DBAL/UnitOfWorkMiddleware.php
+++ b/DBAL/UnitOfWorkMiddleware.php
@@ -9,7 +9,6 @@ use Exception;
  */
 class UnitOfWorkMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterface
 {
-    private TransactionMiddleware $tx;
     private array $news = [];
     private array $dirty = [];
     private array $delete = [];


### PR DESCRIPTION
## Summary
- delete property declarations that duplicate promoted properties across several DBAL classes

## Testing
- `composer run-script test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e40226b0832cbf899f8fed5df2d4