### PR TITLE
Add CONTRIBUTING instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+This project requires **PHP 8.1** or newer.
+
+## Setup
+
+1. Install PHP following your platform's instructions.
+2. Install [Composer](https://getcomposer.org/).
+3. Install development dependencies:
+
+   ```bash
+   composer install
+   ```
+
+## Running the Test Suite
+
+After installing the dependencies, execute:
+
+```bash
+composer run-script test
+```
+
+This will run the PHPUnit tests located in the `tests/` directory.


### PR DESCRIPTION
## Summary
- document PHP and Composer setup
- mention running `composer install` before `composer run-script test`

## Testing
- `composer install` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e5795154832c99b1d16e27c0aaca