### PR TITLE
Fix typed property issue in LazyRelation

### DIFF
--- a/DBAL/LazyRelation.php
+++ b/DBAL/LazyRelation.php
@@ -19,7 +19,7 @@ class LazyRelation implements IteratorAggregate, JsonSerializable
  * @return void
  */
 
-    public function __construct(private callable $loader)
+    public function __construct(private $loader)
     {
     }
 


### PR DESCRIPTION
## Summary
- remove `callable` type from `$loader` property to avoid fatal error when running tests

## Testing
- `composer run-script test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e66f5608832c9a0181333bdbc524