### PR TITLE
Add Crud import to ResultIteratorTest

### DIFF
--- a/tests/ResultIteratorTest.php
+++ b/tests/ResultIteratorTest.php
@@ -2,6 +2,7 @@
 use PHPUnit\Framework\TestCase;
 use DBAL\QueryBuilder\Query;
 use DBAL\ResultIterator;
+use DBAL\Crud;
 
 class ResultIteratorTest extends TestCase
 {


### PR DESCRIPTION
## Summary
- include Crud in ResultIteratorTest imports

## Testing
- `vendor/bin/phpunit --colors=never` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6867e8a72b44832c966e850450d28807