### PR TITLE
Add SQL injection test for eqf operator in OData middleware

### DIFF
--- a/tests/SqlInjectionTest.php
+++ b/tests/SqlInjectionTest.php
@@ -43,4 +43,18 @@ class SqlInjectionTest extends TestCase
         $count = (int)$pdo->query('SELECT COUNT(*) FROM items')->fetchColumn();
         $this->assertEquals(1, $count);
     }
+
+    public function testODataMiddlewareIgnoresEqfInjection()
+    {
+        $pdo = $this->createPdo();
+        $mw = new ODataMiddleware();
+        $crud = $mw->attach((new Crud($pdo))->from('items'));
+        try {
+            $mw->query("$filter=id eqf '1; DROP TABLE items; --'");
+        } catch (\Throwable $e) {
+            // Ignore driver errors while testing for SQL injection
+        }
+        $count = (int)$pdo->query('SELECT COUNT(*) FROM items')->fetchColumn();
+        $this->assertEquals(1, $count);
+    }
 }


### PR DESCRIPTION
## Summary
- extend SqlInjectionTest with a test for injections using the `eqf` operator in ODataMiddleware

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f4ad2d94832c975bec68bf13b0f3