### PR TITLE
Fix ODataMiddleware tests

### DIFF
--- a/tests/SqlInjectionTest.php
+++ b/tests/SqlInjectionTest.php
@@ -38,7 +38,7 @@ class SqlInjectionTest extends TestCase
         $pdo = $this->createPdo();
         $mw = new ODataMiddleware();
         $crud = $mw->attach((new Crud($pdo))->from('items'));
-        $rows = $mw->query("$filter=name eq 'safe'; DROP TABLE items; --");
+        $rows = $mw->query("\$filter=name eq 'safe'; DROP TABLE items; --");
         $this->assertCount(1, $rows);
         $count = (int)$pdo->query('SELECT COUNT(*) FROM items')->fetchColumn();
         $this->assertEquals(1, $count);
@@ -50,7 +50,7 @@ class SqlInjectionTest extends TestCase
         $mw = new ODataMiddleware();
         $crud = $mw->attach((new Crud($pdo))->from('items'));
         try {
-            $mw->query("$filter=id eqf '1; DROP TABLE items; --'");
+            $mw->query("\$filter=id eqf '1; DROP TABLE items; --'");
         } catch (\Throwable $e) {
             // Ignore driver errors while testing for SQL injection
         }


### PR DESCRIPTION
## Summary
- escape `$` in ODataMiddleware tests so literal `$filter` strings are used

## Testing
- `composer run-script test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fa9517a4832cbe6e4f138c06d141