### PR TITLE
Improve middleware documentation

### DIFF
--- a/DBAL/CacheMiddleware.php
+++ b/DBAL/CacheMiddleware.php
@@ -4,19 +4,27 @@ namespace DBAL;
 use DBAL\QueryBuilder\MessageInterface;
 
 /**
- * Clase/Interfaz CacheMiddleware
+ * Middleware that caches the result of SELECT statements.
+ *
+ * A custom {@see CacheStorageInterface} implementation can be passed to the
+ * constructor. When omitted an in-memory storage is used. The entire cache is
+ * flushed whenever an INSERT, UPDATE or DELETE query is executed.
  */
 class CacheMiddleware implements MiddlewareInterface
 {
-/** @var mixed */
+    /**
+     * Storage backend used to persist cached query results.
+     *
+     * @var CacheStorageInterface
+     */
     private $storage;
 
-/**
- * __construct
- * @param CacheStorageInterface $storage
- * @return void
- */
-
+    /**
+     * Initialise the middleware.
+     *
+     * @param CacheStorageInterface|null $storage Optional custom cache storage
+     *        implementation. If omitted an in-memory cache is used.
+     */
     public function __construct(CacheStorageInterface $storage = null)
     {
         $this->storage = $storage ?: new MemoryCacheStorage();
@@ -51,12 +59,11 @@ class CacheMiddleware implements MiddlewareInterface
         return sha1($msg->readMessage() . '|' . serialize($msg->getValues()));
     }
 
-/**
- * fetch
- * @param MessageInterface $msg
- * @return mixed
- */
-
+    /**
+     * Retrieve cached rows for the given SELECT message.
+     *
+     * Non-SELECT statements always return `null`.
+     */
     public function fetch(MessageInterface $msg)
     {
         if ($msg->type() !== MessageInterface::MESSAGE_TYPE_SELECT) {
@@ -65,13 +72,9 @@ class CacheMiddleware implements MiddlewareInterface
         return $this->storage->get($this->key($msg));
     }
 
-/**
- * save
- * @param MessageInterface $msg
- * @param array $rows
- * @return void
- */
-
+    /**
+     * Store rows for the provided SELECT message in the cache.
+     */
     public function save(MessageInterface $msg, array $rows): void
     {
         if ($msg->type() !== MessageInterface::MESSAGE_TYPE_SELECT) {

--- a/DBAL/DevelopmentErrorMiddleware.php
+++ b/DBAL/DevelopmentErrorMiddleware.php
@@ -4,21 +4,36 @@ namespace DBAL;
 use DBAL\QueryBuilder\MessageInterface;
 
 /**
- * Clase/Interfaz DevelopmentErrorMiddleware
+ * Middleware that installs a simple error page handler for development.
+ *
+ * When an uncaught exception occurs an HTML page is rendered. The appearance
+ * can be customised using the options passed to the constructor.
  */
 class DevelopmentErrorMiddleware implements MiddlewareInterface
 {
+    /** Whether to output a text representation of the error to STDERR. */
     private bool $console;
+
+    /** Directory where rendered pages will be stored or null. */
     private ?string $persistPath;
+
+    /** Selected colour theme: "light" or "dark". */
     private string $theme;
+
+    /** Font size used for the rendered HTML page. */
     private string $fontSize;
 
-/**
- * __construct
- * @param array $options
- * @return void
- */
-
+    /**
+     * Create the middleware.
+     *
+     * Supported options:
+     *  - `console` (bool): when true a text version of the error is written to
+     *    STDERR.
+     *  - `persistPath` (string): directory where rendered pages will be stored.
+     *    If omitted no persistence takes place.
+     *  - `theme` (string): "light" or "dark".
+     *  - `fontSize` (string): "small", "medium" or "large".
+     */
     public function __construct(array $options = [])
     {
         $this->console = isset($options['console']) ? (bool)$options['console'] : false;
@@ -36,23 +51,17 @@ class DevelopmentErrorMiddleware implements MiddlewareInterface
         set_exception_handler([$this, 'handleException']);
     }
 
-/**
- * __invoke
- * @param MessageInterface $msg
- * @return void
- */
-
+    /**
+     * Part of the middleware chain; it performs no action.
+     */
     public function __invoke(MessageInterface $msg): void
     {
         // no-op
     }
 
-/**
- * handleException
- * @param \Throwable $e
- * @return void
- */
-
+    /**
+     * Render the error page and terminate execution.
+     */
     public function handleException(\Throwable $e): void
     {
         $html = $this->renderHtml($e);
@@ -137,12 +146,9 @@ class DevelopmentErrorMiddleware implements MiddlewareInterface
         return "function setTheme(t){document.body.classList.remove('light','dark');document.body.classList.add(t)}function setFont(s){document.body.classList.remove('font-small','font-medium','font-large');document.body.classList.add('font-'+s)}";
     }
 
-/**
- * persist
- * @param string $html
- * @return void
- */
-
+    /**
+     * Save the rendered HTML page to the configured directory if enabled.
+     */
     private function persist(string $html): void
     {
         if ($this->persistPath === null) {

--- a/DBAL/LinqMiddleware.php
+++ b/DBAL/LinqMiddleware.php
@@ -4,27 +4,24 @@ namespace DBAL;
 use DBAL\QueryBuilder\MessageInterface;
 
 /**
- * Clase/Interfaz LinqMiddleware
+ * Middleware that provides LINQ-style helper methods for querying.
+ *
+ * When attached to a {@see Crud} instance it exposes `any()`, `none()`, `all()`,
+ * `notAll()`, `count()`, `max()`, `min()` and `sum()` methods.
  */
 class LinqMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterface
 {
-/**
- * __invoke
- * @param MessageInterface $msg
- * @return void
- */
-
+    /**
+     * Part of the middleware chain; it performs no action.
+     */
     public function __invoke(MessageInterface $msg): void
     {
         // no-op
     }
 
-/**
- * countRows
- * @param Crud $crud
- * @return int
- */
-
+    /**
+     * Helper used by other methods to count rows.
+     */
     private function countRows(Crud $crud): int
     {
         $rows = iterator_to_array($crud->select('COUNT(*) AS c'));

--- a/DBAL/TransactionMiddleware.php
+++ b/DBAL/TransactionMiddleware.php
@@ -5,28 +5,35 @@ use PDO;
 use DBAL\QueryBuilder\MessageInterface;
 
 /**
- * Clase/Interfaz TransactionMiddleware
+ * Middleware that exposes helpers to manage database transactions.
+ *
+ * It records whether queries were executed inside a transaction and provides
+ * `begin()`, `commit()` and `rollback()` methods.
  */
 class TransactionMiddleware implements MiddlewareInterface
 {
+    /**
+     * Log of transaction status for each executed message.
+     *
+     * @var bool[]
+     */
     private array $log = [];
+
+    /** Indicates whether a transaction is currently active. */
     private bool $inTx = false;
 
-/**
- * __construct
- * @param PDO $pdo
- * @return void
- */
-
+    /**
+     * Create a new instance bound to a PDO connection.
+     *
+     * @param PDO $pdo Database connection used for transaction control.
+     */
     public function __construct(private PDO $pdo)
-    {    }
+    {
+    }
 
-/**
- * __invoke
- * @param MessageInterface $msg
- * @return void
- */
-
+    /**
+     * Record the transaction state for the executed message.
+     */
     public function __invoke(MessageInterface $msg): void
     {
         // record transaction state on each query
@@ -67,21 +74,19 @@ class TransactionMiddleware implements MiddlewareInterface
         $this->inTx = false;
     }
 
-/**
- * getLog
- * @return array
- */
-
+    /**
+     * Get the transaction status recorded for each executed message.
+     *
+     * @return bool[]
+     */
     public function getLog(): array
     {
         return $this->log;
     }
 
-/**
- * inTransaction
- * @return bool
- */
-
+    /**
+     * Determine if the connection is currently inside a transaction.
+     */
     public function inTransaction(): bool
     {
         return $this->inTx;


### PR DESCRIPTION
## Summary
- expand explanations in middleware docblocks
- add details about available configuration options

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686808121290832c9f2f3fd98e482316