### PR TITLE
Add OData middleware documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,8 @@ $crud = (new DBAL\Crud($pdo))
 
 `ODataMiddleware` converts an OData style query string into a DBAL query. The
 middleware parses `$filter`, `$orderby`, `$top`, `$skip` and `$select`
-parameters and applies them to a `Crud` instance.
+parameters and applies them to a `Crud` instance. See
+[`docs/odata.md`](docs/odata.md) for a detailed reference.
 
 ```php
 $mw = new DBAL\ODataMiddleware();

--- a/docs/odata.md
+++ b/docs/odata.md
@@ -1,0 +1,49 @@
+# OData Middleware
+
+`ODataMiddleware` converts OData style query strings into calls on a `Crud` instance. It understands `$filter`, `$orderby`, `$top`, `$skip` and `$select` parameters so that HTTP query strings can directly drive database queries.
+
+## Purpose
+
+The middleware bridges external APIs that expose OData inspired parameters with DBAL. It parses the query string, builds the equivalent filters and ordering clauses and keeps track of the fields requested via `$select`.
+
+## API
+
+### apply()
+
+`apply(Crud $crud, string $query): Crud` parses the given query string and returns a cloned `Crud` object with the corresponding limit, offset, ordering and filters applied.
+
+### query()
+
+`query(string $odata): array` applies the query to the `Crud` instance attached through `attach()` and returns the resulting rows as an array.
+
+### getFields()
+
+`getFields(): array` returns the list of fields extracted from `$select`. When no `$select` parameter is present an empty array is returned.
+
+## Examples
+
+### Filtering and ordering
+```php
+$mw   = new DBAL\ODataMiddleware();
+$crud = $mw->attach((new DBAL\Crud($pdo))->from('books'));
+
+$query = '$filter=author_id eq 1 and price gt 10&$orderby=title desc';
+$filtered = $mw->apply($crud, $query);
+$rows = iterator_to_array($filtered->select(...$mw->getFields()));
+```
+
+### Pagination and field selection
+```php
+$query = '$skip=5&$top=10&$select=title,price';
+$paged = $mw->apply($crud, $query);
+$fields = $mw->getFields();
+foreach ($paged->select(...$fields) as $row) {
+    // process $row
+}
+```
+
+### Parsing an HTTP query string
+```php
+$odata = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
+$rows  = $mw->query($odata);
+```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -20,6 +20,7 @@ The documentation in this folder is organised into several topics:
 
 - **`overview.md`** – this document. It introduces the library, outlines the main features and explains where to find more information.
 - **`middlewares.md`** – descriptions of the built‑in middlewares and how to create custom ones.
+- **`odata.md`** – using `ODataMiddleware` to translate query strings into filters, ordering and pagination.
 - **`integration.md`** – integration examples for Slim, Lumen and plain PHP usage.
 - **`examples.md`** – practical scenarios such as managing a book store, handling cinema tickets or implementing a logistics API.
 


### PR DESCRIPTION
## Summary
- document how to use ODataMiddleware
- crosslink README to the new documentation
- add reference to `odata.md` in docs overview

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680df24148832c8aeabca37c0ff7da