### PR TITLE
Document LazyRelation usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,8 @@ foreach ($books->with('author')->select() as $book) {
 }
 ```
 
+See [LazyRelation documentation](docs/lazy-relations.md) for details on how related rows are loaded on demand and serialised.
+
 ### Bulk insert with transactions
 
 ```php

--- a/docs/lazy-relations.md
+++ b/docs/lazy-relations.md
@@ -1,0 +1,36 @@
+# LazyRelation
+
+`LazyRelation` is a small helper returned when related rows are not eagerly loaded with `with()`. It delays the underlying query until the relation value is actually used.
+
+## Automatic loading
+
+A `LazyRelation` instance receives a loader callback. The callback is executed only once, the first time the relation is accessed. Subsequent calls return the previously loaded data.
+
+```php
+$book = iterator_to_array($books->where(['id' => 1])->select())[0];
+// relation not fetched yet
+$title = $book['title'];
+$author = $book['author'];        // triggers the query behind the scenes
+```
+
+## Iterability
+
+`LazyRelation` implements `IteratorAggregate`. When used in a `foreach` loop it automatically loads the related rows and yields them one by one.
+
+```php
+$book = iterator_to_array($books->where(['id' => 1])->select())[0];
+foreach ($book['reviews'] as $review) {   // loader runs on first iteration
+    echo $review['text'];
+}
+```
+
+## JSON serialisation
+
+The object also implements `JsonSerializable`. Calling `json_encode()` on an array or object containing `LazyRelation` instances causes each relation to be loaded and converted to plain data.
+
+```php
+$book = iterator_to_array($books->where(['id' => 1])->select())[0];
+echo json_encode($book);  // author and reviews are included
+```
+
+`LazyRelation` can be manually invoked as `$book['author']()` or `$book['author']->get()` if needed but is usually transparent when accessed, iterated or encoded.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,6 +22,7 @@ The documentation in this folder is organised into several topics:
 - **`middlewares.md`** – descriptions of the built‑in middlewares and how to create custom ones.
 - **`integration.md`** – integration examples for Slim, Lumen and plain PHP usage.
 - **`examples.md`** – practical scenarios such as managing a book store, handling cinema tickets or implementing a logistics API.
+- **`lazy-relations.md`** – details the `LazyRelation` helper used for on-demand loading of related rows.
 
 Each file can be read in isolation, but together they provide a comprehensive guide to DBAL.
 


### PR DESCRIPTION
## Summary
- document LazyRelation behaviour and usage in new `docs/lazy-relations.md`
- link new doc from overview
- link LazyRelation doc from README relation example

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68680df77e08832c8fc0af9c9c2195da