### PR TITLE
Improve cache middleware docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ $crud = (new DBAL\Crud($pdo))
 
 ### Cache middleware
 
-`CacheMiddleware` stores the result of SELECT statements and invalidates the cache when data changes. The package includes in-memory and SQLite storage adapters.
+`CacheMiddleware` caches the result of SELECT statements and clears the cache when data changes. It defaults to the in-memory `MemoryCacheStorage`, but you can use the provided `SqliteCacheStorage` or any custom `CacheStorageInterface` implementation.
 
 ### Active record
 

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -6,7 +6,56 @@ DBAL ships with several optional middlewares that can be attached to a `Crud` in
 Provides `ActiveRecord` objects with dynamic getters and setters. Use `$record->update()` to persist modified fields.
 
 ## CacheMiddleware
-Caches SELECT query results using an in-memory or custom storage. Results are invalidated when insert, update or delete statements run.
+
+`CacheMiddleware` stores the rows returned by SELECT statements. By default it
+relies on an in-memory `MemoryCacheStorage` that lives for the duration of the
+request. Whenever an insert, update or delete is executed through the attached
+`Crud` instance the cache is flushed to keep results consistent.
+
+If you need persistence across requests you can provide a different storage
+backend. DBAL includes a `SqliteCacheStorage` adapter:
+
+```php
+$cache = new DBAL\CacheMiddleware(
+    new DBAL\SqliteCacheStorage(__DIR__ . '/cache.sqlite')
+);
+$crud = (new DBAL\Crud($pdo))
+    ->from('users')
+    ->withMiddleware($cache);
+```
+
+Custom storages can be implemented by fulfilling the
+`CacheStorageInterface` contract:
+
+```php
+use DBAL\CacheStorageInterface;
+
+class ArrayCache implements CacheStorageInterface
+{
+    private array $data = [];
+
+    public function get(string $key)
+    {
+        return $this->data[$key] ?? null;
+    }
+
+    public function set(string $key, $value): void
+    {
+        $this->data[$key] = $value;
+    }
+
+    public function delete(string $key = null): void
+    {
+        if ($key === null) {
+            $this->data = [];
+        } else {
+            unset($this->data[$key]);
+        }
+    }
+}
+
+$crud = $crud->withMiddleware(new DBAL\CacheMiddleware(new ArrayCache()));
+```
 
 ## TransactionMiddleware
 Wraps operations inside database transactions and exposes `begin()`, `commit()` and `rollback()` helpers.


### PR DESCRIPTION
## Summary
- document CacheMiddleware storage options in `docs/middlewares.md`
- clarify default memory store and `SqliteCacheStorage`
- mention custom cache storage implementation
- update README middleware section

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680df9ec84832c9091843ed705b8d1