### PR TITLE
Add strict typing declarations to PHP files

### DIFF
--- a/DBAL/AbmEventInterface.php
+++ b/DBAL/AbmEventInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 /**

--- a/DBAL/AbmEventMiddleware.php
+++ b/DBAL/AbmEventMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/ActiveRecord.php
+++ b/DBAL/ActiveRecord.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 /**

--- a/DBAL/ActiveRecordMiddleware.php
+++ b/DBAL/ActiveRecordMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/Attributes/BelongsTo.php
+++ b/DBAL/Attributes/BelongsTo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\Attributes;
 use Attribute;
 

--- a/DBAL/Attributes/Email.php
+++ b/DBAL/Attributes/Email.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\Attributes;
 use Attribute;
 

--- a/DBAL/Attributes/HasMany.php
+++ b/DBAL/Attributes/HasMany.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\Attributes;
 use Attribute;
 

--- a/DBAL/Attributes/HasOne.php
+++ b/DBAL/Attributes/HasOne.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\Attributes;
 use Attribute;
 

--- a/DBAL/Attributes/IntegerType.php
+++ b/DBAL/Attributes/IntegerType.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\Attributes;
 use Attribute;
 

--- a/DBAL/Attributes/MaxLength.php
+++ b/DBAL/Attributes/MaxLength.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\Attributes;
 use Attribute;
 

--- a/DBAL/Attributes/Required.php
+++ b/DBAL/Attributes/Required.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\Attributes;
 use Attribute;
 

--- a/DBAL/Attributes/StringType.php
+++ b/DBAL/Attributes/StringType.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\Attributes;
 use Attribute;
 

--- a/DBAL/CacheMiddleware.php
+++ b/DBAL/CacheMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/CacheStorageInterface.php
+++ b/DBAL/CacheStorageInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 /**

--- a/DBAL/Crud.php
+++ b/DBAL/Crud.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\Query;

--- a/DBAL/CrudAwareMiddlewareInterface.php
+++ b/DBAL/CrudAwareMiddlewareInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 /**

--- a/DBAL/DevelopmentErrorMiddleware.php
+++ b/DBAL/DevelopmentErrorMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/EntityValidationInterface.php
+++ b/DBAL/EntityValidationInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/EntityValidationMiddleware.php
+++ b/DBAL/EntityValidationMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use InvalidArgumentException;

--- a/DBAL/FirstLastMiddleware.php
+++ b/DBAL/FirstLastMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/GlobalFilterMiddleware.php
+++ b/DBAL/GlobalFilterMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/LazyRelation.php
+++ b/DBAL/LazyRelation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use IteratorAggregate;

--- a/DBAL/LinqMiddleware.php
+++ b/DBAL/LinqMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/MemoryCacheStorage.php
+++ b/DBAL/MemoryCacheStorage.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 /**

--- a/DBAL/MiddlewareInterface.php
+++ b/DBAL/MiddlewareInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/ODataMiddleware.php
+++ b/DBAL/ODataMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\DynamicFilterBuilder;

--- a/DBAL/QueryBuilder/DynamicFilterBuilder.php
+++ b/DBAL/QueryBuilder/DynamicFilterBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Message.php
+++ b/DBAL/QueryBuilder/Message.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder;
 
 /**

--- a/DBAL/QueryBuilder/MessageInterface.php
+++ b/DBAL/QueryBuilder/MessageInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder;
 
 /**

--- a/DBAL/QueryBuilder/Node/ChangeNode.php
+++ b/DBAL/QueryBuilder/Node/ChangeNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/EmptyNode.php
+++ b/DBAL/QueryBuilder/Node/EmptyNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/FieldNode.php
+++ b/DBAL/QueryBuilder/Node/FieldNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/FieldsNode.php
+++ b/DBAL/QueryBuilder/Node/FieldsNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/FilterNode.php
+++ b/DBAL/QueryBuilder/Node/FilterNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/GroupNode.php
+++ b/DBAL/QueryBuilder/Node/GroupNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/HavingNode.php
+++ b/DBAL/QueryBuilder/Node/HavingNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/JoinNode.php
+++ b/DBAL/QueryBuilder/Node/JoinNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/JoinsNode.php
+++ b/DBAL/QueryBuilder/Node/JoinsNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/LimitNode.php
+++ b/DBAL/QueryBuilder/Node/LimitNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/Node.php
+++ b/DBAL/QueryBuilder/Node/Node.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 /**

--- a/DBAL/QueryBuilder/Node/NodeInterface.php
+++ b/DBAL/QueryBuilder/Node/NodeInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/NotImplementedNode.php
+++ b/DBAL/QueryBuilder/Node/NotImplementedNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 /**

--- a/DBAL/QueryBuilder/Node/OrderNode.php
+++ b/DBAL/QueryBuilder/Node/OrderNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/QueryNode.php
+++ b/DBAL/QueryBuilder/Node/QueryNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/TableNode.php
+++ b/DBAL/QueryBuilder/Node/TableNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/TablesNode.php
+++ b/DBAL/QueryBuilder/Node/TablesNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Node/WhereNode.php
+++ b/DBAL/QueryBuilder/Node/WhereNode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/QueryBuilder/Query.php
+++ b/DBAL/QueryBuilder/Query.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\QueryBuilder;
 
 use DBAL\ResultIterator;

--- a/DBAL/RelationDefinition.php
+++ b/DBAL/RelationDefinition.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 /**

--- a/DBAL/RelationLoaderMiddleware.php
+++ b/DBAL/RelationLoaderMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/ResultGenerator.php
+++ b/DBAL/ResultGenerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use Generator;

--- a/DBAL/ResultIterator.php
+++ b/DBAL/ResultIterator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/DBAL/Schema/SchemaColumnBuilder.php
+++ b/DBAL/Schema/SchemaColumnBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\Schema;
 
 /**

--- a/DBAL/Schema/SchemaTableBuilder.php
+++ b/DBAL/Schema/SchemaTableBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL\Schema;
 
 /**

--- a/DBAL/SchemaMiddleware.php
+++ b/DBAL/SchemaMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use PDO;

--- a/DBAL/SqlSchemaTableBuilder.php
+++ b/DBAL/SqlSchemaTableBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use PDO;

--- a/DBAL/SqliteCacheStorage.php
+++ b/DBAL/SqliteCacheStorage.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use PDO;

--- a/DBAL/TransactionMiddleware.php
+++ b/DBAL/TransactionMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use PDO;

--- a/DBAL/UnitOfWorkMiddleware.php
+++ b/DBAL/UnitOfWorkMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace DBAL;
 
 use DBAL\QueryBuilder\MessageInterface;

--- a/tests/AbmEventMiddlewareTest.php
+++ b/tests/AbmEventMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\AbmEventMiddleware;

--- a/tests/ActiveRecordMiddlewareTest.php
+++ b/tests/ActiveRecordMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\ActiveRecordMiddleware;

--- a/tests/CacheMiddlewareTest.php
+++ b/tests/CacheMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\CacheMiddleware;

--- a/tests/CrudBulkInsertTest.php
+++ b/tests/CrudBulkInsertTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 

--- a/tests/CrudEagerLoadingTest.php
+++ b/tests/CrudEagerLoadingTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\EntityValidationMiddleware;

--- a/tests/CrudMiddlewareMagicCallTest.php
+++ b/tests/CrudMiddlewareMagicCallTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\QueryBuilder\MessageInterface;

--- a/tests/CrudMiddlewareTest.php
+++ b/tests/CrudMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 

--- a/tests/CrudStreamTest.php
+++ b/tests/CrudStreamTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 

--- a/tests/CrudTest.php
+++ b/tests/CrudTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\QueryBuilder\Query;

--- a/tests/DynamicFilterBuilderTest.php
+++ b/tests/DynamicFilterBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\QueryBuilder\DynamicFilterBuilder;
 

--- a/tests/EntityValidationMiddlewareTest.php
+++ b/tests/EntityValidationMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\EntityValidationMiddleware;

--- a/tests/FilterNodeTest.php
+++ b/tests/FilterNodeTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\QueryBuilder\Message;
 use DBAL\QueryBuilder\MessageInterface;

--- a/tests/FirstLastMiddlewareTest.php
+++ b/tests/FirstLastMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\FirstLastMiddleware;

--- a/tests/GlobalFilterMiddlewareTest.php
+++ b/tests/GlobalFilterMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\GlobalFilterMiddleware;

--- a/tests/LimitNodeTest.php
+++ b/tests/LimitNodeTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\QueryBuilder\Message;
 use DBAL\QueryBuilder\Node\LimitNode;

--- a/tests/LinqMiddlewareTest.php
+++ b/tests/LinqMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\LinqMiddleware;

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\QueryBuilder\Message;
 use DBAL\QueryBuilder\MessageInterface;

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\QueryBuilder\Query;
 use DBAL\QueryBuilder\Node\FieldNode;

--- a/tests/RelationDefinitionTest.php
+++ b/tests/RelationDefinitionTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\EntityValidationMiddleware;
 use DBAL\RelationDefinition;

--- a/tests/RelationLoaderMiddlewareTest.php
+++ b/tests/RelationLoaderMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\RelationLoaderMiddleware;

--- a/tests/ResultIteratorGroupByTest.php
+++ b/tests/ResultIteratorGroupByTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 

--- a/tests/ResultIteratorTest.php
+++ b/tests/ResultIteratorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\QueryBuilder\Query;
 use DBAL\ResultIterator;

--- a/tests/SchemaMiddlewareTest.php
+++ b/tests/SchemaMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\SchemaMiddleware;

--- a/tests/SchemaTableBuilderTest.php
+++ b/tests/SchemaTableBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Schema\SchemaTableBuilder;
 

--- a/tests/SqlInjectionTest.php
+++ b/tests/SqlInjectionTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\LinqMiddleware;

--- a/tests/TransactionUnitOfWorkMiddlewareTest.php
+++ b/tests/TransactionUnitOfWorkMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
 use DBAL\TransactionMiddleware;


### PR DESCRIPTION
## Summary
- enable strict types for library and tests by adding `declare(strict_types=1)`

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686813459af8832c957089e94f8e2041