### PR TITLE
Add built-in LIKE filter

### DIFF
--- a/DBAL/QueryBuilder/Node/FilterNode.php
+++ b/DBAL/QueryBuilder/Node/FilterNode.php
@@ -202,10 +202,15 @@ FilterNode::filter('in', function($field, $values, $message)
 
 FilterNode::filter('between', function($field, $values, $message)
 {
-	return $message->insertAfter(sprintf('( %s between ? AND ? )', $field), MessageInterface::SEPARATOR_OR)->addValues((array) $values);
+        return $message->insertAfter(sprintf('( %s between ? AND ? )', $field), MessageInterface::SEPARATOR_OR)->addValues((array) $values);
 });
 
 FilterNode::filter('eqf', function($field, $value, $message)
 {
-	return $message->insertAfter(sprintf('%s = %s', $field, $value), MessageInterface::SEPARATOR_OR);
+        return $message->insertAfter(sprintf('%s = %s', $field, $value), MessageInterface::SEPARATOR_OR);
+});
+
+FilterNode::filter('like', function($field, $value, $msg) {
+        return $msg->insertAfter(sprintf('%s LIKE ?', $field), MessageInterface::SEPARATOR_OR)
+                   ->addValues([$value]);
 });

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ $books->where(['id' => $bookId])->delete();
 
 ```php
 $results = $books
-    ->where(['title__like' => '%robot%'])
+    ->where(['title__like' => '%robot%']) // built-in LIKE filter
     ->order('ASC', ['title'])
     ->select('id', 'title');
 ```
@@ -567,7 +567,7 @@ $results = $books
 
 ```php
 $byAuthor = $books->where(function ($q) {
-    $q->author_id__gt(1)->title__like('%dune%');
+    $q->author_id__gt(1)->title__like('%dune%'); // built-in LIKE filter
 })->select('id', 'title');
 ```
 ### Working with relations

--- a/tests/FilterNodeTest.php
+++ b/tests/FilterNodeTest.php
@@ -22,4 +22,12 @@ class FilterNodeTest extends TestCase
         $msg = $node->send(new Message());
         $this->assertEquals('id in (SELECT id FROM users)', $msg->readMessage());
     }
+
+    public function testFilterLike()
+    {
+        $node = new FilterNode(['title__like' => '%dune%']);
+        $msg = $node->send(new Message());
+        $this->assertEquals('title LIKE ?', $msg->readMessage());
+        $this->assertEquals(['%dune%'], $msg->getValues());
+    }
 }


### PR DESCRIPTION
## Summary
- register a built-in `like` filter in `FilterNode`
- show use of `__like` filter in README examples
- test the new `like` filter in `FilterNodeTest`

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868134690e0832cb9168f5bee069723