### PR TITLE
Add fetchAll method to Crud

### DIFF
--- a/DBAL/Crud.php
+++ b/DBAL/Crud.php
@@ -188,6 +188,21 @@ class Crud extends Query
         }
 
     /**
+     * Returns all rows from a SELECT query as an array.
+     *
+     * This is a convenience method equivalent to
+     * `iterator_to_array($this->select(...$fields))`.
+     *
+     * @param string|array ...$fields Optional fields to select.
+     * @return array                   Array with the fetched rows.
+     */
+
+        public function fetchAll(...$fields): array
+        {
+                return iterator_to_array($this->select(...$fields));
+        }
+
+    /**
      * Streams the result of a SELECT query using a generator.
      *
      * Middlewares are executed when the returned generator starts

--- a/README.md
+++ b/README.md
@@ -200,6 +200,19 @@ $crud->stream(function ($row) {
 }, 'id', 'name');
 ```
 
+### Fetch all results
+
+`Crud::fetchAll()` is a convenience method that returns an array with all rows
+from a query.
+
+```php
+$rows = $crud->fetchAll('id', 'name');
+
+foreach ($rows as $row) {
+    echo $row['name'];
+}
+```
+
 ### Middlewares
 
 Middlewares allow you to intercept query execution for tasks like logging or
@@ -354,7 +367,7 @@ foreach ($users as $user) {
 }
 
 // Lazy load
-$user = iterator_to_array($crud->where(['id' => 1])->select())[0];
+$user = $crud->where(['id' => 1])->fetchAll()[0];
 $profile = $user['profile'];
 echo $profile['photo'];
 ```
@@ -374,7 +387,7 @@ $crud = (new DBAL\Crud($pdo))
     ->withMiddleware($rel)
     ->with('profile');
 
-$users = iterator_to_array($crud->select());
+$users = $crud->fetchAll();
 ```
 
 Lazy loading works the same and the related records are fetched only when needed.
@@ -495,7 +508,7 @@ $pdo->exec('INSERT INTO users(name) VALUES ("Alice")');
 $crud = (new DBAL\Crud($pdo))->from('users');
 $ar   = (new DBAL\ActiveRecordMiddleware())->attach($crud);
 
-$record = iterator_to_array($ar->where(['id__eq' => 1])->select())[0];
+$record = $ar->where(['id__eq' => 1])->fetchAll()[0];
 $record->name = 'Alice2'; // or $record->set__name('Alice2');
 $record->update(); // only changed fields are written
 ```

--- a/tests/CrudFetchAllTest.php
+++ b/tests/CrudFetchAllTest.php
@@ -1,0 +1,24 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+
+class CrudFetchAllTest extends TestCase
+{
+    private function pdoWithData()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $pdo->exec('INSERT INTO t(name) VALUES ("A"), ("B")');
+        return $pdo;
+    }
+
+    public function testFetchAllReturnsAllRows()
+    {
+        $crud = (new Crud($this->pdoWithData()))->from('t');
+        $rows = $crud->fetchAll('name');
+        $this->assertEquals([
+            ['name' => 'A'],
+            ['name' => 'B'],
+        ], $rows);
+    }
+}


### PR DESCRIPTION
## Summary
- add `fetchAll()` convenience method
- document the new method
- provide usage tests for `Crud::fetchAll`

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681349b1ac832c87d12ae3c30af2ea