### PR TITLE
Fix fetchAll to use associative arrays

### DIFF
--- a/DBAL/ResultIterator.php
+++ b/DBAL/ResultIterator.php
@@ -59,7 +59,7 @@ class ResultIterator implements \Iterator, \JsonSerializable
 
                 $this->stm = $this->pdo->prepare($this->message->readMessage());
                 $this->stm->execute($this->message->getValues());
-                $this->rows = $this->stm->fetchAll();
+                $this->rows = $this->stm->fetchAll(\PDO::FETCH_ASSOC);
 
                 foreach ($this->middlewares as $mw) {
                         if (method_exists($mw, 'save')) {


### PR DESCRIPTION
## Summary
- ensure ResultIterator uses PDO::FETCH_ASSOC when fetching

## Testing
- `composer run-script test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681cbfac9c832c8403ea2bd4e5b1bd