### PR TITLE
Document additional Linq middleware helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,10 @@ $lastUser = $crud->last('id', 'name');
 
 ### Linq middleware
 
-`LinqMiddleware` exposes helper methods to query for the existence of records.
+`LinqMiddleware` exposes helper methods to check for the existence of rows and
+run simple aggregations (see
+[docs/middlewares.md#linqmiddleware](docs/middlewares.md#linqmiddleware) for a
+full reference).
 
 ```php
 $linq = new DBAL\LinqMiddleware();
@@ -300,7 +303,12 @@ $crud = (new DBAL\Crud($pdo))
     ->withMiddleware($linq);
 
 $hasInactive = $crud->any(['active__eq' => 0]);
-$allActive = $crud->all(['active__eq' => 1]);
+$noGuests    = $crud->none(['role__eq' => 'guest']);
+$allActive   = $crud->all(['active__eq' => 1]);
+$notAllFree  = $crud->notAll(['plan__eq' => 'free']);
+
+$totalUsers = $crud->count();      // also max(), min() and sum()
+$oldest     = $crud->max('age');
 ```
 
 ### Entity validation middleware

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -93,7 +93,16 @@ Allows executing callbacks after insert, bulk insert, update or delete operation
 Adds `first()`, `firstOrDefault()`, `last()` and `lastOrDefault()` to quickly fetch a single row.
 
 ## LinqMiddleware
-Adds `any()`, `all()`, `count()`, `max()`, `min()` and `sum()` methods for quick queries.
+Convenience methods for existence checks and quick aggregations:
+
+- `any($filters)` returns `true` if at least one row matches.
+- `none($filters)` returns `true` when no rows match.
+- `all($filters)` returns `true` if every row matches (or no rows exist).
+- `notAll($filters)` returns `true` when at least one row does not match.
+- `count($filters)` returns the number of matching rows.
+- `max($field)` returns the maximum value of a column.
+- `min($field)` returns the minimum value of a column.
+- `sum($field)` returns the sum of a numeric column.
 
 ## EntityValidationMiddleware
 Provides a fluent API to validate data and declare relations for eager or lazy loading.


### PR DESCRIPTION
## Summary
- expand Linq middleware section in docs with details for any(), none(), all(), notAll(), count(), max(), min() and sum()
- extend README example to show none() and notAll() and mention aggregation helpers

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681f324fc8832cb3c9b67706b7edca