### PR TITLE
Document additional Linq helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,8 @@ $lastUser = $crud->last('id', 'name');
 
 ### Linq middleware
 
-`LinqMiddleware` exposes helper methods to query for the existence of records.
+`LinqMiddleware` exposes several helper methods for quick checks and aggregations.
+See [LinqMiddleware docs](docs/middlewares.md#linqmiddleware) for the full list.
 
 ```php
 $linq = new DBAL\LinqMiddleware();
@@ -300,7 +301,14 @@ $crud = (new DBAL\Crud($pdo))
     ->withMiddleware($linq);
 
 $hasInactive = $crud->any(['active__eq' => 0]);
+$noneInactive = $crud->none(['active__eq' => 1]);
 $allActive = $crud->all(['active__eq' => 1]);
+$someInactive = $crud->notAll(['active__eq' => 1]);
+
+$total = $crud->count();
+$highestId = $crud->max('id');
+$lowestId = $crud->min('id');
+$totalAge = $crud->sum('age');
 ```
 
 ### Entity validation middleware

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -93,7 +93,16 @@ Allows executing callbacks after insert, bulk insert, update or delete operation
 Adds `first()`, `firstOrDefault()`, `last()` and `lastOrDefault()` to quickly fetch a single row.
 
 ## LinqMiddleware
-Adds `any()`, `all()`, `count()`, `max()`, `min()` and `sum()` methods for quick queries.
+Adds helper methods for quick queries:
+
+- `any(...$filters)` returns `true` when at least one row matches.
+- `none(...$filters)` returns `true` when no rows match.
+- `all(...$filters)` returns `true` when every row matches or there are no rows.
+- `notAll(...$filters)` returns `true` when some rows do not match.
+- `count(...$filters)` returns the number of matching rows.
+- `max($field)` returns the maximum value of the given field.
+- `min($field)` returns the minimum value of the given field.
+- `sum($field)` returns the sum of the values in the given field.
 
 ## EntityValidationMiddleware
 Provides a fluent API to validate data and declare relations for eager or lazy loading.


### PR DESCRIPTION
## Summary
- list all Linq middleware helpers in the docs
- extend the README example to cover `none()` and `notAll()`
- mention aggregation helpers and link to the docs

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681e3cf5d8832c9f9ce94ecf0e5f0f