### PR TITLE
Add LoggingMiddleware with docs and tests

### DIFF
--- a/DBAL/LoggingMiddleware.php
+++ b/DBAL/LoggingMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+namespace DBAL;
+
+use Psr\Log\LoggerInterface;
+use DBAL\QueryBuilder\MessageInterface;
+
+/**
+ * Middleware that logs executed SQL statements and their bound values.
+ *
+ * The constructor accepts either a PSR-3 {@see LoggerInterface} or a callable
+ * taking the SQL string and parameters.
+ */
+class LoggingMiddleware implements MiddlewareInterface
+{
+    /** @var callable|LoggerInterface */
+    private $logger;
+
+    /**
+     * Initialise the middleware with a logger or callable.
+     *
+     * @param callable|LoggerInterface $logger Logger instance or function.
+     */
+    public function __construct(callable|LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Invoked for each query before execution to log the SQL.
+     */
+    public function __invoke(MessageInterface $msg): void
+    {
+        $sql    = $msg->readMessage();
+        $values = $msg->getValues();
+        if ($this->logger instanceof LoggerInterface) {
+            $this->logger->debug($sql, $values);
+        } else {
+            ($this->logger)($sql, $values);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ foreach ($rows as $row) {
 ### Middlewares
 
 Middlewares allow you to intercept query execution for tasks like logging or
-validation.
+validation. DBAL ships with a [LoggingMiddleware](docs/middlewares.md#loggingmiddleware)
+that forwards executed SQL to any PSR-3 logger.
 
 ```php
 $crud = (new DBAL\Crud($pdo))

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -57,6 +57,19 @@ class ArrayCache implements CacheStorageInterface
 $crud = $crud->withMiddleware(new DBAL\CacheMiddleware(new ArrayCache()));
 ```
 
+## LoggingMiddleware
+Logs every executed SQL statement. The constructor accepts a PSR-3 logger or any
+callable receiving the SQL string and bound values.
+
+```php
+use Psr\Log\NullLogger;
+
+$logger = new NullLogger();
+$crud = (new DBAL\Crud($pdo))
+    ->from('users')
+    ->withMiddleware(new DBAL\LoggingMiddleware($logger));
+```
+
 ## TransactionMiddleware
 Wraps operations inside database transactions and exposes `begin()`, `commit()` and `rollback()` helpers.
 

--- a/tests/LoggingMiddlewareTest.php
+++ b/tests/LoggingMiddlewareTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\LoggingMiddleware;
+use Psr\Log\LoggerInterface;
+
+class LoggingMiddlewareTest extends TestCase
+{
+    private function createPdo()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        return $pdo;
+    }
+
+    public function testLoggerInterfaceIsUsed()
+    {
+        $pdo = $this->createPdo();
+        $logger = new class implements LoggerInterface {
+            public array $records = [];
+            public function emergency($m, array $c = []) { $this->log('emergency', $m, $c); }
+            public function alert($m, array $c = [])    { $this->log('alert', $m, $c); }
+            public function critical($m, array $c = []) { $this->log('critical', $m, $c); }
+            public function error($m, array $c = [])    { $this->log('error', $m, $c); }
+            public function warning($m, array $c = [])  { $this->log('warning', $m, $c); }
+            public function notice($m, array $c = [])   { $this->log('notice', $m, $c); }
+            public function info($m, array $c = [])     { $this->log('info', $m, $c); }
+            public function debug($m, array $c = [])    { $this->log('debug', $m, $c); }
+            public function log($level, $message, array $context = []) { $this->records[] = [$level, $message, $context]; }
+        };
+
+        $mw = new LoggingMiddleware($logger);
+        $crud = (new Crud($pdo))->from('test')->withMiddleware($mw);
+
+        $crud->insert(['name' => 'A']);
+
+        $this->assertNotEmpty($logger->records);
+        $this->assertStringContainsString('INSERT INTO', $logger->records[0][1]);
+    }
+
+    public function testCallableLoggerIsUsed()
+    {
+        $pdo = $this->createPdo();
+        $log = [];
+        $callable = function ($sql, $values) use (&$log) {
+            $log[] = [$sql, $values];
+        };
+
+        $mw = new LoggingMiddleware($callable);
+        $crud = (new Crud($pdo))->from('test')->withMiddleware($mw);
+
+        $crud->insert(['name' => 'A']);
+
+        $this->assertCount(1, $log);
+        $this->assertStringContainsString('INSERT INTO', $log[0][0]);
+    }
+}

--- a/vendor/Psr/Log/LoggerInterface.php
+++ b/vendor/Psr/Log/LoggerInterface.php
@@ -1,0 +1,15 @@
+<?php
+namespace Psr\Log;
+
+interface LoggerInterface
+{
+    public function emergency($message, array $context = []);
+    public function alert($message, array $context = []);
+    public function critical($message, array $context = []);
+    public function error($message, array $context = []);
+    public function warning($message, array $context = []);
+    public function notice($message, array $context = []);
+    public function info($message, array $context = []);
+    public function debug($message, array $context = []);
+    public function log($level, $message, array $context = []);
+}

--- a/vendor/autoload.php
+++ b/vendor/autoload.php
@@ -1,14 +1,19 @@
 <?php
 spl_autoload_register(function ($class) {
-    $prefix = 'DBAL\\';
-    $base_dir = __DIR__ . '/../DBAL/';
-    $len = strlen($prefix);
-    if (strncmp($prefix, $class, $len) !== 0) {
-        return;
-    }
-    $relative = substr($class, $len);
-    $file = $base_dir . str_replace('\\', '/', $relative) . '.php';
-    if (file_exists($file)) {
-        require $file;
+    $prefixes = [
+        'DBAL\\'   => __DIR__ . '/../DBAL/',
+        'Psr\\Log\\' => __DIR__ . '/Psr/Log/',
+    ];
+
+    foreach ($prefixes as $prefix => $base_dir) {
+        $len = strlen($prefix);
+        if (strncmp($prefix, $class, $len) !== 0) {
+            continue;
+        }
+        $relative = substr($class, $len);
+        $file = $base_dir . str_replace('\\', '/', $relative) . '.php';
+        if (file_exists($file)) {
+            require $file;
+        }
     }
 });


### PR DESCRIPTION
## Summary
- implement `LoggingMiddleware` to log executed SQL
- add PSR-3 `LoggerInterface` stub and autoloader support
- document logging middleware usage
- add unit tests

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686824926c5c832c8798ac44a5c6f585