### PR TITLE
Add QueryCounterMiddleware

### DIFF
--- a/DBAL/QueryCounterMiddleware.php
+++ b/DBAL/QueryCounterMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+/**
+ * Middleware that counts the number of executed queries.
+ */
+class QueryCounterMiddleware implements MiddlewareInterface
+{
+    /** Number of processed messages. */
+    private int $count = 0;
+
+    /**
+     * Increment the internal counter on each query execution.
+     */
+    public function __invoke(MessageInterface $msg): void
+    {
+        $this->count++;
+    }
+
+    /**
+     * Get the amount of executed queries.
+     */
+    public function getQueryCount(): int
+    {
+        return $this->count;
+    }
+}

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -149,6 +149,20 @@ Appends extra filters automatically to every SELECT statement.
 ## SchemaMiddleware
 Creates or alters tables through a fluent schema builder.
 
+## QueryCounterMiddleware
+Counts how many queries are executed by a `Crud`. Attach the middleware and call `getQueryCount()` to read the total.
+
+```php
+$counter = new DBAL\QueryCounterMiddleware();
+$crud = (new DBAL\Crud($pdo))
+    ->from('items')
+    ->withMiddleware($counter);
+
+$crud->select();
+$queries = $counter->getQueryCount(); // 1
+```
+
+
 ## DevelopmentErrorMiddleware
 Installs an exception handler that displays a friendly HTML page when an
 uncaught exception occurs. The constructor accepts:

--- a/tests/QueryCounterMiddlewareTest.php
+++ b/tests/QueryCounterMiddlewareTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\QueryCounterMiddleware;
+
+class QueryCounterMiddlewareTest extends TestCase
+{
+    private function createPdo()
+    {
+        return new PDO('sqlite::memory:');
+    }
+
+    public function testCounterIncrements()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+
+        $counter = new QueryCounterMiddleware();
+        $crud = (new Crud($pdo))->from('items')->withMiddleware($counter);
+
+        iterator_to_array($crud->select());
+        $this->assertEquals(1, $counter->getQueryCount());
+
+        $crud->insert(['name' => 'A']);
+        $this->assertEquals(2, $counter->getQueryCount());
+
+        $crud->where(['id__eq' => 1])->update(['name' => 'B']);
+        $this->assertEquals(3, $counter->getQueryCount());
+
+        $crud->where(['id__eq' => 1])->delete();
+        $this->assertEquals(4, $counter->getQueryCount());
+    }
+}


### PR DESCRIPTION
## Summary
- add `QueryCounterMiddleware` to count executed queries
- document how to attach and inspect the query counter middleware
- test query counter on basic CRUD operations

## Testing
- `phpunit tests/QueryCounterMiddlewareTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686824989084832c91b69af87369dbf7