### PR TITLE
Fix missing PSR Log dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     },
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.1",
+        "psr/log": "^1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9"


### PR DESCRIPTION
## Summary
- include `psr/log` so `LoggingMiddlewareTest` can load `Psr\Log\LoggerInterface`

## Testing
- `composer run-script test` *(fails: Interface "Psr\Log\LoggerInterface" not found)*

------
https://chatgpt.com/codex/tasks/task_e_686827a9de1c832c859eac3ce29ba4f9