### PR TITLE
Add EntityCastMiddleware

### DIFF
--- a/DBAL/EntityCastMiddleware.php
+++ b/DBAL/EntityCastMiddleware.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+namespace DBAL;
+
+use ReflectionClass;
+use DBAL\QueryBuilder\MessageInterface;
+use DBAL\RelationDefinition;
+use DBAL\Attributes\HasOne;
+use DBAL\Attributes\HasMany;
+use DBAL\Attributes\BelongsTo;
+
+/**
+ * Middleware that casts result rows into objects of a given class and
+ * infers relations from its attributes for eager loading.
+ */
+class EntityCastMiddleware implements MiddlewareInterface
+{
+    private array $classes = [];
+    private array $relations = [];
+
+    public function __invoke(MessageInterface $msg): void
+    {
+        // no-op
+    }
+
+    /**
+     * Register an entity class for a table. Attribute based relations are
+     * parsed and stored for later joins.
+     */
+    public function register(string $table, string $class): self
+    {
+        $this->classes[$table] = $class;
+        $this->relations[$table] = [];
+
+        $ref = new ReflectionClass($class);
+        foreach ($ref->getProperties() as $prop) {
+            foreach ($prop->getAttributes() as $attr) {
+                $name = $attr->getName();
+                if (in_array($name, [HasOne::class, HasMany::class, BelongsTo::class], true)) {
+                    $def  = new RelationDefinition($prop->getName());
+                    $inst = $attr->newInstance();
+                    switch ($name) {
+                        case HasOne::class:
+                            $def->hasOne($inst->table);
+                            break;
+                        case HasMany::class:
+                            $def->hasMany($inst->table);
+                            break;
+                        case BelongsTo::class:
+                            $def->belongsTo($inst->table);
+                            break;
+                    }
+                    $def->on("{$table}.{$inst->localKey}", '=', "{$inst->table}.{$inst->foreignKey}");
+                    $this->relations[$table][$prop->getName()] = $def;
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns relation definitions for a given table.
+     */
+    public function getRelations(string $table): array
+    {
+        return $this->relations[$table] ?? [];
+    }
+
+    /**
+     * Attach the middleware to a Crud instance and cast rows for the table.
+     */
+    public function attach(Crud $crud, string $table): Crud
+    {
+        if (!isset($this->classes[$table])) {
+            return $crud->withMiddleware($this);
+        }
+        $class = $this->classes[$table];
+        $crud  = $crud->map(function (array $row) use ($class) {
+            $obj = new $class();
+            foreach ($row as $k => $v) {
+                $obj->$k = $v;
+            }
+            return $obj;
+        });
+        return $crud->withMiddleware($this);
+    }
+}

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -5,6 +5,22 @@ DBAL ships with several optional middlewares that can be attached to a `Crud` in
 ## ActiveRecordMiddleware
 Provides `ActiveRecord` objects with dynamic getters and setters. Use `$record->update()` to persist modified fields.
 
+## EntityCastMiddleware
+Casts query results into instances of a specified class and inspects its attribute
+annotations to configure relations for eager loading. Attach the middleware and
+register the class mapped to a table:
+
+```php
+$caster = (new DBAL\EntityCastMiddleware())
+    ->register('users', UserEntity::class);
+
+$crud = (new DBAL\Crud($pdo))->from('users');
+$crud = $caster->attach($crud, 'users');
+```
+
+Relations defined with `#[HasOne]`, `#[HasMany]` or `#[BelongsTo]` on the class
+properties will be available for lazy or eager loading via `with()`.
+
 ## CacheMiddleware
 
 `CacheMiddleware` stores the rows returned by SELECT statements. By default it

--- a/tests/EntityCastMiddlewareTest.php
+++ b/tests/EntityCastMiddlewareTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\EntityCastMiddleware;
+use DBAL\LazyRelation;
+use DBAL\Attributes\HasOne;
+use DBAL\QueryBuilder\MessageInterface;
+
+class CastUser {
+    public $id;
+    public $name;
+    #[HasOne('profiles', 'id', 'user_id')]
+    public $profile;
+}
+
+class EntityCastMiddlewareTest extends TestCase
+{
+    private function createPdo()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $pdo->exec('CREATE TABLE profiles (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, bio TEXT)');
+        $pdo->exec("INSERT INTO users (name) VALUES ('Alice')");
+        $pdo->exec("INSERT INTO profiles (user_id, bio) VALUES (1, 'bio')");
+        return $pdo;
+    }
+
+    public function testRowsAreCastedToObjects()
+    {
+        $pdo = $this->createPdo();
+        $mw  = (new EntityCastMiddleware())->register('users', CastUser::class);
+        $crud = (new Crud($pdo))->from('users');
+        $crud = $mw->attach($crud, 'users');
+
+        $rows = iterator_to_array($crud->select());
+        $this->assertInstanceOf(CastUser::class, $rows[0]);
+        $this->assertInstanceOf(LazyRelation::class, $rows[0]->profile);
+    }
+
+    public function testEagerLoadAddsJoin()
+    {
+        $pdo = $this->createPdo();
+        $log = [];
+        $logger = function (MessageInterface $m) use (&$log) { $log[] = $m->readMessage(); };
+
+        $mw  = (new EntityCastMiddleware())->register('users', CastUser::class);
+        $crud = (new Crud($pdo))->from('users');
+        $crud = $mw->attach($crud, 'users')->withMiddleware($logger)->with('profile');
+
+        iterator_to_array($crud->select('users.id', 'profiles.bio'));
+        $this->assertStringContainsString('JOIN profiles', $log[0]);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `EntityCastMiddleware` to cast rows into objects and derive relations from attributes
- document the new middleware
- test casting behaviour and eager loading

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682a856cf4832c934b851f3f7e1210