### PR TITLE
Improve naming consistency

### DIFF
--- a/DBAL/CrudEventInterface.php
+++ b/DBAL/CrudEventInterface.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 namespace DBAL;
 
 /**
- * Clase/Interfaz AbmEventInterface
+ * Event hooks triggered after CRUD operations.
  */
-interface AbmEventInterface extends MiddlewareInterface
+interface CrudEventInterface extends MiddlewareInterface
 {
 /**
  * afterInsert

--- a/DBAL/CrudEventMiddleware.php
+++ b/DBAL/CrudEventMiddleware.php
@@ -5,9 +5,9 @@ namespace DBAL;
 use DBAL\QueryBuilder\MessageInterface;
 
 /**
- * Clase/Interfaz AbmEventMiddleware
+ * Middleware that invokes callbacks after CRUD operations.
  */
-class AbmEventMiddleware implements AbmEventInterface
+class CrudEventMiddleware implements CrudEventInterface
 {
     private ?\Closure $onInsert;
     private ?\Closure $onUpdate;

--- a/DBAL/QueryBuilder/Message.php
+++ b/DBAL/QueryBuilder/Message.php
@@ -37,9 +37,9 @@ class Message implements MessageInterface
 		{
 			throw new \InvalidArgumentException('Type of message passed to method "join" is not equals to self this type');
 		}
-		$clon = $this->insertAfter($message->readMessage(), $separator);
-		$clon = $clon->addValues($message->values);
-		return $clon; 
+		$clone = $this->insertAfter($message->readMessage(), $separator);
+		$clone = $clone->addValues($message->values);
+		return $clone; 
 	}
 /**
  * insertBefore
@@ -50,12 +50,12 @@ class Message implements MessageInterface
 
 	public function insertBefore($string, $separator = MessageInterface::SEPARATOR_SPACE)
 	{
-		$clon = clone $this;
-		if (strlen($clon->message) > 0)
-			$clon->message = $string . $separator . $clon->message;			
+		$clone = clone $this;
+		if (strlen($clone->message) > 0)
+			$clone->message = $string . $separator . $clone->message;			
 		else
-			$clon->message = $string;
-		return $clon;
+			$clone->message = $string;
+		return $clone;
 	}
 /**
  * replace
@@ -66,9 +66,9 @@ class Message implements MessageInterface
 
 	public function replace($old, $now)
 	{
-		$clon = clone $this;
-		$clon->message = str_replace($old, $now, $clon->message);
-		return $clon;
+		$clone = clone $this;
+		$clone->message = str_replace($old, $now, $clone->message);
+		return $clone;
 	}
 /**
  * insertAfter
@@ -79,12 +79,12 @@ class Message implements MessageInterface
 
 	public function insertAfter($string, $separator = MessageInterface::SEPARATOR_SPACE)
 	{
-		$clon = clone $this;
-		if (strlen($clon->message) > 0)
-			$clon->message = $clon->message . $separator . $string;		
+		$clone = clone $this;
+		if (strlen($clone->message) > 0)
+			$clone->message = $clone->message . $separator . $string;		
 		else
-			$clon->message = $string;
-		return $clon;
+			$clone->message = $string;
+		return $clone;
 	}
 /**
  * addValues
@@ -94,9 +94,9 @@ class Message implements MessageInterface
 
 	public function addValues(array $values)
 	{
-		$clon = clone $this;
-		$clon->values = array_merge($clon->values, $values);
-		return $clon;
+		$clone = clone $this;
+		$clone->values = array_merge($clone->values, $values);
+		return $clone;
 	}
 /**
  * getValues

--- a/DBAL/QueryBuilder/Node/Node.php
+++ b/DBAL/QueryBuilder/Node/Node.php
@@ -15,7 +15,7 @@ abstract class Node implements NodeInterface
         protected bool $isEmpty;
 
         /** @var array<string|int, NodeInterface> */
-        protected array $childs = [];
+        protected array $children = [];
         /**
          * Append a child node to this node.
          *
@@ -27,9 +27,9 @@ abstract class Node implements NodeInterface
         public function appendChild(NodeInterface $node, $name = null)
         {
                 if ($name === null) {
-                        $name = (count($this->childs) > 0) ? 1 + count($this->childs) : 0;
+                        $name = (count($this->children) > 0) ? 1 + count($this->children) : 0;
                 }
-                $this->childs[$name] = $node;
+                $this->children[$name] = $node;
                 return $name;
         }
         /**
@@ -40,7 +40,7 @@ abstract class Node implements NodeInterface
          */
         public function hasChild($name)
         {
-                return isset($this->childs[$name]);
+                return isset($this->children[$name]);
         }
         /**
          * Retrieve a child node or an {@see EmptyNode} if it does not exist.
@@ -50,8 +50,8 @@ abstract class Node implements NodeInterface
          */
         public function getChild($name)
         {
-                if (isset($this->childs[$name])) {
-                        return $this->childs[$name];
+                if (isset($this->children[$name])) {
+                        return $this->children[$name];
                 }
                 return new EmptyNode();
         }
@@ -63,9 +63,9 @@ abstract class Node implements NodeInterface
          */
         public function removeChild($name)
         {
-                if (isset($this->childs[$name])) {
-                        $node = $this->childs[$name];
-                        unset($this->childs[$name]);
+                if (isset($this->children[$name])) {
+                        $node = $this->children[$name];
+                        unset($this->children[$name]);
                         return $node;
                 }
                 return new EmptyNode();
@@ -77,7 +77,7 @@ abstract class Node implements NodeInterface
          */
         public function allChildren()
         {
-                return $this->childs;
+                return $this->children;
         }
         /**
          * Indicate if this node is considered empty.
@@ -91,8 +91,8 @@ abstract class Node implements NodeInterface
          */
         public function __clone()
         {
-                foreach ($this->childs as $key => $node) {
-                        $this->childs[$key] = clone $node;
+                foreach ($this->children as $key => $node) {
+                        $this->children[$key] = clone $node;
                 }
         }
 }

--- a/DBAL/QueryBuilder/Node/NodeInterface.php
+++ b/DBAL/QueryBuilder/Node/NodeInterface.php
@@ -17,7 +17,7 @@ interface NodeInterface
 	public function send(MessageInterface $message);
 
 	/**
-	* Append child node to list childs
+        * Append a child node to the list of children
 	* @param NodeInterface the node to append
 	* @param string the node name
 	* @return string the node name
@@ -32,7 +32,7 @@ interface NodeInterface
 	public function hasChild($name);
 
 	/**
-	* Get child node of list childs or empty node if is not exists (or not implemented)
+        * Get child node from the list of children or an empty node if it does not exist (or is not implemented)
 	* @param string the node name
 	* @return NodeInterface the child node
 	*/
@@ -46,8 +46,8 @@ interface NodeInterface
 	public function removeChild($name);
 
 	/**
-	* Get all child nodes or empty array if is not exists (or not implemented)
-	* @return NodeInterface[]|[] the list of childs or empty array if is not implemented
+        * Get all child nodes or an empty array if none exist (or not implemented)
+        * @return NodeInterface[]|[] the list of children or empty array if not implemented
 	*/
 	public function allChildren();
 

--- a/DBAL/QueryBuilder/Query.php
+++ b/DBAL/QueryBuilder/Query.php
@@ -34,14 +34,14 @@ class Query extends QueryNode
 
 	public function from(...$tables)
 	{
-		$clon = clone $this;
+		$clone = clone $this;
                foreach ($tables as $table) {
                        $_table = ($table instanceof TableNode)
                                ? $table
                                : new TableNode($table);
-                       $clon->getChild('tables')->appendChild($_table);
+                       $clone->getChild('tables')->appendChild($_table);
                }
-		return $clon;
+		return $clone;
 	}
 /**
  * join
@@ -76,9 +76,9 @@ class Query extends QueryNode
 
         public function innerJoin($table, ...$on)
         {
-                $clon = clone $this;
-                $clon->join(JoinNode::INNER_JOIN, $table, $on);
-                return $clon;
+                $clone = clone $this;
+                $clone->join(JoinNode::INNER_JOIN, $table, $on);
+                return $clone;
         }
 /**
  * leftJoin
@@ -89,9 +89,9 @@ class Query extends QueryNode
 
         public function leftJoin($table, ...$on)
         {
-                $clon = clone $this;
-                $clon->join(JoinNode::LEFT_JOIN, $table, $on);
-                return $clon;
+                $clone = clone $this;
+                $clone->join(JoinNode::LEFT_JOIN, $table, $on);
+                return $clone;
         }
 /**
  * rightJoin
@@ -102,9 +102,9 @@ class Query extends QueryNode
 
         public function rightJoin($table, ...$on)
         {
-                $clon = clone $this;
-                $clon->join(JoinNode::RIGHT_JOIN, $table, $on);
-                return $clon;
+                $clone = clone $this;
+                $clone->join(JoinNode::RIGHT_JOIN, $table, $on);
+                return $clone;
         }
 /**
  * where
@@ -114,7 +114,7 @@ class Query extends QueryNode
 
         public function where(...$filters)
         {
-                $clon = clone $this;
+                $clone = clone $this;
                 foreach ($filters as $filter) {
                         if (is_callable($filter)) {
                                 $builder = new DynamicFilterBuilder();
@@ -124,16 +124,16 @@ class Query extends QueryNode
                         if ($filter instanceof FilterNode) {
                                 if (count($filter->getParts()) === 0 && count($filter->allChildren()) > 1) {
                                         foreach ($filter->allChildren() as $child) {
-                                                $clon->getChild('where')->appendChild($child);
+                                                $clone->getChild('where')->appendChild($child);
                                         }
                                 } else {
-                                        $clon->getChild('where')->appendChild($filter);
+                                        $clone->getChild('where')->appendChild($filter);
                                 }
                         } elseif (is_array($filter)) {
-                                $clon->getChild('where')->appendChild(new FilterNode($filter));
+                                $clone->getChild('where')->appendChild(new FilterNode($filter));
                         }
                 }
-                return $clon;
+                return $clone;
         }
 /**
  * having
@@ -143,10 +143,10 @@ class Query extends QueryNode
 
 	public function having(array ...$filters)
 	{
-		$clon = clone $this;
+		$clone = clone $this;
 		foreach ($filters as $filter)
-			$clon->getChild('having')->appendChild(new FilterNode($filter));
-		return $clon;
+			$clone->getChild('having')->appendChild(new FilterNode($filter));
+		return $clone;
 	}
 /**
  * group
@@ -156,10 +156,10 @@ class Query extends QueryNode
 
         public function group(...$fields)
         {
-                $clon = clone $this;
+                $clone = clone $this;
                 foreach ($fields as $field)
-                        $clon->getChild('group')->appendChild(new FieldNode($field));
-                return $clon;
+                        $clone->getChild('group')->appendChild(new FieldNode($field));
+                return $clone;
         }
 /**
  * groupBy
@@ -169,8 +169,8 @@ class Query extends QueryNode
 
         public function groupBy(...$fields)
         {
-                $clon = clone $this;
-                return $clon->group(...$fields);
+                $clone = clone $this;
+                return $clone->group(...$fields);
         }
 /**
  * order
@@ -181,10 +181,10 @@ class Query extends QueryNode
 
         public function order($type, array $fields)
         {
-                $clon = clone $this;
+                $clone = clone $this;
                 foreach ($fields as $field)
-                        $clon->getChild('order')->appendChild(new FieldNode(sprintf('%s %s', $field, $type)));
-		return $clon;
+                        $clone->getChild('order')->appendChild(new FieldNode(sprintf('%s %s', $field, $type)));
+		return $clone;
 	}
 /**
  * desc
@@ -194,8 +194,8 @@ class Query extends QueryNode
 
 	public function desc(...$fields)
 	{
-		$clon = clone $this;
-		return $clon->order(OrderNode::ORDER_DESC, $fields);
+		$clone = clone $this;
+		return $clone->order(OrderNode::ORDER_DESC, $fields);
 	}
 /**
  * asc
@@ -205,8 +205,8 @@ class Query extends QueryNode
 
 	public function asc(...$fields)
 	{
-		$clon = clone $this;
-		return $clon->order(OrderNode::ORDER_ASC, $fields);
+		$clone = clone $this;
+		return $clone->order(OrderNode::ORDER_ASC, $fields);
 	}
 /**
  * limit
@@ -216,9 +216,9 @@ class Query extends QueryNode
 
 	public function limit($limit)
 	{
-		$clon = clone $this;
-		$clon->getChild('limit')->setLimit($limit);
-		return $clon;
+		$clone = clone $this;
+		$clone->getChild('limit')->setLimit($limit);
+		return $clone;
 	}
 /**
  * offset
@@ -228,9 +228,9 @@ class Query extends QueryNode
 
 	public function offset($offset)
 	{
-		$clon = clone $this;
-		$clon->getChild('limit')->setOffset($offset);
-		return $clon;
+		$clone = clone $this;
+		$clone->getChild('limit')->setOffset($offset);
+		return $clone;
 	}
 /**
  * buildSelect
@@ -240,21 +240,21 @@ class Query extends QueryNode
 
 	public function buildSelect(...$fields)
 	{
-		$clon = clone $this;
+		$clone = clone $this;
 		$message = new Message(MessageInterface::MESSAGE_TYPE_SELECT);
 		if (sizeof($fields) == 0) {
-			$message = $clon->send($message);
+			$message = $clone->send($message);
 		} else {
-			$old = $clon->removeChild('fields');
-			$clon->appendChild(new FieldsNode, 'fields');
+			$old = $clone->removeChild('fields');
+			$clone->appendChild(new FieldsNode, 'fields');
 			foreach ($fields as $field) {
 				if (!$field instanceof FieldNode)
 					$field = new FieldNode($field);
-				$clon->getChild('fields')->appendChild($field);
+				$clone->getChild('fields')->appendChild($field);
 			}
-			$message = $clon->send($message);
-			$clon->removeChild('fields');
-			$clon->appendChild($old, 'fields');
+			$message = $clone->send($message);
+			$clone->removeChild('fields');
+			$clone->appendChild($old, 'fields');
 		}
 		return $message;
 	}
@@ -266,10 +266,10 @@ class Query extends QueryNode
 
         public function buildInsert(array $fields)
         {
-                $clon = clone $this;
+                $clone = clone $this;
                 $message = new Message(MessageInterface::MESSAGE_TYPE_INSERT);
-                $clon->getChild('change')->setFields($fields);
-                $message = $clon->send($message);
+                $clone->getChild('change')->setFields($fields);
+                $message = $clone->send($message);
                 return $message;
         }
 /**
@@ -280,10 +280,10 @@ class Query extends QueryNode
 
         public function buildBulkInsert(array $rows)
         {
-                $clon = clone $this;
+                $clone = clone $this;
                 $message = new Message(MessageInterface::MESSAGE_TYPE_INSERT);
-                $clon->getChild('change')->setRows($rows);
-                $message = $clon->send($message);
+                $clone->getChild('change')->setRows($rows);
+                $message = $clone->send($message);
                 return $message;
         }
 /**
@@ -294,10 +294,10 @@ class Query extends QueryNode
 
         public function buildUpdate(array $fields)
         {
-                $clon = clone $this;
+                $clone = clone $this;
                 $message = new Message(MessageInterface::MESSAGE_TYPE_UPDATE);
-                $clon->getChild('change')->setFields($fields);
-		$message = $clon->send($message);
+                $clone->getChild('change')->setFields($fields);
+		$message = $clone->send($message);
 		return $message;
 	}
 /**
@@ -307,9 +307,9 @@ class Query extends QueryNode
 
 	public function buildDelete()
 	{
-		$clon = clone $this;
+		$clone = clone $this;
 		$message = new Message(MessageInterface::MESSAGE_TYPE_DELETE);
-		$message = $clon->send($message);
+		$message = $clone->send($message);
 		return $message;
 	}
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A lightweight Database Abstraction Layer for PHP.
 - ActiveRecord support with dynamic properties
 - Caching middleware with pluggable storage
 - Transaction and Unit of Work middlewares
-- ABM event hooks to listen for inserts, updates or deletes
+- CRUD event hooks to listen for inserts, updates or deletes
 - Improved documentation and error pages
 
 
@@ -526,9 +526,9 @@ $record->update(); // only changed fields are written
 
 `TransactionMiddleware` exposes helpers to start, commit or roll back transactions. `UnitOfWorkMiddleware` batches multiple operations and applies them atomically via `commit()`.  
 
-### ABM event middleware
+### CRUD event middleware
 
-`AbmEventMiddleware` lets you execute callbacks after inserts, bulk inserts, updates or deletes to implement custom hooks.
+`CrudEventMiddleware` lets you execute callbacks after inserts, bulk inserts, updates or deletes to implement custom hooks.
 
 ### Query timing middleware
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -29,7 +29,7 @@ $crud->alterTable('books')
     ->execute();
 ```
 
-### Basic operations (ABM)
+### Basic operations (CRUD)
 ```php
 $books = (new DBAL\Crud($pdo))->from('books');
 
@@ -144,7 +144,7 @@ $crud->alterTable('reservations')
     ->execute();
 ```
 
-### Basic operations (ABM)
+### Basic operations (CRUD)
 ```php
 $reservations = (new DBAL\Crud($pdo))->from('reservations');
 
@@ -256,7 +256,7 @@ $crud->alterTable('packages')
     ->execute();
 ```
 
-### Basic operations (ABM)
+### Basic operations (CRUD)
 ```php
 $packages = (new DBAL\Crud($pdo))->from('packages');
 

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -115,7 +115,7 @@ $crud->registerDelete('items', ['id' => 2]);
 $crud->commit();
 ```
 
-## AbmEventMiddleware
+## CrudEventMiddleware
 Allows executing callbacks after insert, bulk insert, update or delete operations.
 
 ## FirstLastMiddleware

--- a/tests/CrudEventMiddlewareTest.php
+++ b/tests/CrudEventMiddlewareTest.php
@@ -2,9 +2,9 @@
 declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Crud;
-use DBAL\AbmEventMiddleware;
+use DBAL\CrudEventMiddleware;
 
-class AbmEventMiddlewareTest extends TestCase
+class CrudEventMiddlewareTest extends TestCase
 {
     private function createPdo()
     {
@@ -17,7 +17,7 @@ class AbmEventMiddlewareTest extends TestCase
         $pdo->exec('CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
 
         $events = [];
-        $mw = new AbmEventMiddleware(
+        $mw = new CrudEventMiddleware(
             function ($t, $fields, $id) use (&$events) { $events[] = ['insert', $t, $fields, $id]; },
             function ($t, $fields, $count) use (&$events) { $events[] = ['update', $t, $fields, $count]; },
             function ($t, $count) use (&$events) { $events[] = ['delete', $t, $count]; },


### PR DESCRIPTION
## Summary
- rename AbmEvent* to CrudEvent* for clarity
- rename internal `$childs` property to `$children`
- rename temporary `$clon` variables to `$clone`
- update documentation and tests

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682e2d25c4832ca6a0f0bc5a4823bd