### PR TITLE
Add Hooks helpers

### DIFF
--- a/DBAL/Hooks/helpers.php
+++ b/DBAL/Hooks/helpers.php
@@ -1,0 +1,160 @@
+<?php
+namespace DBAL\Hooks;
+
+use PDO;
+use DBAL\Crud;
+use DBAL\CacheMiddleware;
+use DBAL\CacheStorageInterface;
+use DBAL\TransactionMiddleware;
+use DBAL\UnitOfWorkMiddleware;
+use DBAL\ActiveRecordMiddleware;
+use DBAL\FirstLastMiddleware;
+use DBAL\LinqMiddleware;
+use DBAL\DevelopmentErrorMiddleware;
+use DBAL\GlobalFilterMiddleware;
+use DBAL\SchemaMiddleware;
+use DBAL\EntityValidationMiddleware;
+use DBAL\AbmEventMiddleware;
+use DBAL\ODataMiddleware;
+
+/**
+ * Create a Crud instance bound to a table.
+ */
+function useCrud(PDO $pdo, string $table): Crud
+{
+    return (new Crud($pdo))->from($table);
+}
+
+/**
+ * Attach caching to the given Crud instance.
+ */
+function useCache(Crud $crud, CacheStorageInterface $storage = null): Crud
+{
+    $mw = new CacheMiddleware($storage);
+    return $crud->withMiddleware($mw);
+}
+
+/**
+ * Attach transaction middleware and return it along with the Crud.
+ *
+ * @return array{Crud, TransactionMiddleware}
+ */
+function useTransaction(Crud $crud): array
+{
+    $pdo = (function () {
+        return $this->connection;
+    })->call($crud);
+    $tx = new TransactionMiddleware($pdo);
+    $crud = $crud->withMiddleware($tx);
+    return [$crud, $tx];
+}
+
+/**
+ * Attach unit of work support. A TransactionMiddleware is created internally.
+ *
+ * @return array{Crud, UnitOfWorkMiddleware}
+ */
+function useUnitOfWork(Crud $crud): array
+{
+    [$crud, $tx] = useTransaction($crud);
+    $uow = new UnitOfWorkMiddleware($tx);
+    $crud = $crud->withMiddleware($uow);
+    return [$crud, $uow];
+}
+
+/**
+ * Decorate result rows with ActiveRecord objects.
+ */
+function useActiveRecord(Crud $crud): Crud
+{
+    $mw = new ActiveRecordMiddleware();
+    return $mw->attach($crud);
+}
+
+/**
+ * Add First/Last helpers to the Crud instance.
+ */
+function useFirstLast(Crud $crud): Crud
+{
+    $mw = new FirstLastMiddleware();
+    return $mw->attach($crud);
+}
+
+/**
+ * Add LINQ-like helper methods to the Crud instance.
+ */
+function useLinq(Crud $crud): Crud
+{
+    $mw = new LinqMiddleware();
+    return $crud->withMiddleware($mw);
+}
+
+/**
+ * Register entity validation middleware.
+ */
+function useValidation(Crud $crud, EntityValidationMiddleware $validator): Crud
+{
+    return $crud->withMiddleware($validator);
+}
+
+/**
+ * Apply global or table-specific filters to SELECT statements.
+ */
+function useGlobalFilter(Crud $crud, array $tableFilters = [], array $globalFilters = []): Crud
+{
+    $mw = new GlobalFilterMiddleware($tableFilters, $globalFilters);
+    return $crud->withMiddleware($mw);
+}
+
+/**
+ * Attach schema helper middleware and return it.
+ *
+ * @return array{Crud, SchemaMiddleware}
+ */
+function useSchema(Crud $crud): array
+{
+    $pdo = (function () {
+        return $this->connection;
+    })->call($crud);
+    $mw = new SchemaMiddleware($pdo);
+    $crud = $crud->withMiddleware($mw);
+    return [$crud, $mw];
+}
+
+/**
+ * Register middleware to display detailed errors during development.
+ */
+function useDevelopmentErrors(Crud $crud, array $options = []): Crud
+{
+    $mw = new DevelopmentErrorMiddleware($options);
+    return $crud->withMiddleware($mw);
+}
+
+/**
+ * Register callbacks triggered after insert, update or delete operations.
+ *
+ * @return array{Crud, AbmEventMiddleware}
+ */
+function useAbmEvents(
+    Crud $crud,
+    ?callable $onInsert = null,
+    ?callable $onUpdate = null,
+    ?callable $onDelete = null,
+    ?callable $onBulkInsert = null
+): array {
+    $mw = new AbmEventMiddleware($onInsert, $onUpdate, $onDelete, $onBulkInsert);
+    $crud = $crud->withMiddleware($mw);
+    return [$crud, $mw];
+}
+
+/**
+ * Attach the OData middleware for parsing OData query strings.
+ *
+ * @return array{Crud, ODataMiddleware}
+ */
+function useOData(Crud $crud): array
+{
+    $mw = new ODataMiddleware();
+    $crud = $crud->withMiddleware($mw);
+    return [$crud, $mw];
+}

--- a/README.md
+++ b/README.md
@@ -556,4 +556,28 @@ try {
 
 Middlewares are simple classes that implement `MiddlewareInterface`. Create your own to add behaviours such as auditing or soft deletes and attach them with `withMiddleware()`.
 
+## Hook Helpers
+
+Several convenience functions are available under the `DBAL\Hooks` namespace.
+These helpers configure a `Crud` instance with common middlewares.
+
+```php
+use function DBAL\Hooks\useCrud;
+use function DBAL\Hooks\useCache;
+use function DBAL\Hooks\useTransaction;
+
+$pdo = new PDO('sqlite::memory:');
+$crud = useCrud($pdo, 'items');
+$crud = useCache($crud);
+[$crud, $tx] = useTransaction($crud);
+
+$tx->begin();
+$crud->insert(['name' => 'Example']);
+$tx->commit();
+```
+
+Each `use*` function returns the configured `Crud` instance and, when
+applicable, the middleware object so you can call helper methods like
+`begin()` or `commit()`.
+
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,10 @@
     "autoload": {
         "psr-4": {
             "DBAL\\": "DBAL/"
-        }
+        },
+        "files": [
+            "DBAL/Hooks/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,24 @@
+# Hook Helpers
+
+The `DBAL\Hooks` namespace provides utility functions that wrap common
+middlewares. They allow quickly configuring a `Crud` instance without
+manually instantiating each middleware.
+
+## Example
+
+```php
+use function DBAL\Hooks\{useCrud, useCache, useTransaction, useUnitOfWork};
+
+$pdo  = new PDO('sqlite::memory:');
+$crud = useCrud($pdo, 'items');
+$crud = useCache($crud);
+[$crud, $tx] = useTransaction($crud);
+[$crud, $uow] = useUnitOfWork($crud);
+
+$crud->registerNew('items', ['name' => 'A']);
+$crud->commit();
+```
+
+Refer to the function signatures in the source for the full list of
+available helpers.
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -6,4 +6,5 @@ This folder contains extended documentation for the DBAL library.
 * **middlewares.md** – explanation of included middlewares and how to extend them.
 * **integration.md** – examples of integrating DBAL with frameworks such as Slim and Lumen or plain PHP.
 * **examples.md** – practical use cases for book stores, cinemas and logistic APIs.
+* **hooks.md** – helper functions for quickly setting up middlewares.
 

--- a/tests/HooksTest.php
+++ b/tests/HooksTest.php
@@ -1,0 +1,82 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\ActiveRecord;
+use DBAL\TransactionMiddleware;
+use DBAL\UnitOfWorkMiddleware;
+use function DBAL\Hooks\useCrud;
+use function DBAL\Hooks\useCache;
+use function DBAL\Hooks\useTransaction;
+use function DBAL\Hooks\useUnitOfWork;
+use function DBAL\Hooks\useActiveRecord;
+
+class HooksTest extends TestCase
+{
+    private function createPdo()
+    {
+        return new PDO('sqlite::memory:');
+    }
+
+    public function testUseCrudCreatesCrud()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $crud = useCrud($pdo, 'items');
+        $crud->insert(['name' => 'A']);
+        $rows = iterator_to_array($crud->select());
+        $this->assertCount(1, $rows);
+    }
+
+    public function testUseCacheCachesResults()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $pdo->exec('INSERT INTO test(name) VALUES ("A")');
+        $crud = useCrud($pdo, 'test');
+        $crud = useCache($crud);
+        $rows = iterator_to_array($crud->select());
+        $this->assertEquals('A', $rows[0]['name']);
+        $pdo->exec('DELETE FROM test');
+        $rows = iterator_to_array($crud->select());
+        $this->assertEquals('A', $rows[0]['name']);
+    }
+
+    public function testUseTransactionReturnsMiddleware()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $crud = useCrud($pdo, 't');
+        [$crud, $tx] = useTransaction($crud);
+        $this->assertInstanceOf(TransactionMiddleware::class, $tx);
+        $crud->begin();
+        $crud->insert(['name' => 'A']);
+        $crud->commit();
+        $rows = iterator_to_array($crud->select());
+        $this->assertCount(1, $rows);
+        $this->assertTrue($tx->getLog()[0]);
+    }
+
+    public function testUseUnitOfWorkWorks()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $crud = useCrud($pdo, 'items');
+        [$crud, $uow] = useUnitOfWork($crud);
+        $this->assertInstanceOf(UnitOfWorkMiddleware::class, $uow);
+        $crud->registerNew('items', ['name' => 'B']);
+        $crud->commit();
+        $rows = iterator_to_array($crud->select());
+        $this->assertCount(1, $rows);
+    }
+
+    public function testUseActiveRecordReturnsActiveRecordRows()
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $pdo->exec('INSERT INTO users(name) VALUES ("A")');
+        $crud = useCrud($pdo, 'users');
+        $crud = useActiveRecord($crud);
+        $rows = iterator_to_array($crud->select());
+        $this->assertInstanceOf(ActiveRecord::class, $rows[0]);
+    }
+}

--- a/vendor/autoload.php
+++ b/vendor/autoload.php
@@ -12,3 +12,5 @@ spl_autoload_register(function ($class) {
         require $file;
     }
 });
+
+require __DIR__ . '/../DBAL/Hooks/helpers.php';


### PR DESCRIPTION
## Summary
- introduce hooks functions for common middleware setup
- document hook helpers in README and docs
- register autoload for the new helpers
- add unit tests covering the helper functions

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683aa892d4832ca975683ac4439432