### PR TITLE
Attach UnitOfWork before Transaction

### DIFF
--- a/DBAL/Hooks/helpers.php
+++ b/DBAL/Hooks/helpers.php
@@ -56,9 +56,15 @@ function useTransaction(Crud $crud): array
  */
 function useUnitOfWork(Crud $crud): array
 {
-    [$crud, $tx] = useTransaction($crud);
+    $pdo = (function () {
+        return $this->connection;
+    })->call($crud);
+
+    $tx  = new TransactionMiddleware($pdo);
     $uow = new UnitOfWorkMiddleware($tx);
-    $crud = $crud->withMiddleware($uow);
+
+    $crud = $crud->withMiddleware($uow)->withMiddleware($tx);
+
     return [$crud, $uow];
 }
 


### PR DESCRIPTION
## Summary
- update `useUnitOfWork` helper
  - create a `TransactionMiddleware` from the Crud connection
  - add a `UnitOfWorkMiddleware`
  - attach the UoW middleware before the transaction middleware

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68683ddee6dc832ca257f6afcbebde60