### PR TITLE
Update docs for UnitOfWork usage

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -7,12 +7,11 @@ manually instantiating each middleware.
 ## Example
 
 ```php
-use function DBAL\Hooks\{useCrud, useCache, useTransaction, useUnitOfWork};
+use function DBAL\Hooks\{useCrud, useCache, useUnitOfWork};
 
 $pdo  = new PDO('sqlite::memory:');
 $crud = useCrud($pdo, 'items');
 $crud = useCache($crud);
-[$crud, $tx] = useTransaction($crud);
 [$crud, $uow] = useUnitOfWork($crud);
 
 $crud->registerNew('items', ['name' => 'A']);


### PR DESCRIPTION
## Summary
- clarify hook helper imports
- show example using useUnitOfWork only

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683de402c0832c95dd7212942ec1c0