### PR TITLE
Support active record entities and object inserts

### DIFF
--- a/DBAL/ActiveRecordTrait.php
+++ b/DBAL/ActiveRecordTrait.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+namespace DBAL;
+
+trait ActiveRecordTrait
+{
+    private Crud $crud;
+    private array $arOriginal = [];
+
+    public function initActiveRecord(Crud $crud, array $original): void
+    {
+        $this->crud = $crud;
+        $this->arOriginal = $original;
+    }
+
+    public function update(): int
+    {
+        if (!array_key_exists('id', $this->arOriginal)) {
+            throw new \RuntimeException('id field missing');
+        }
+
+        $current = get_object_vars($this);
+        unset($current['crud'], $current['arOriginal']);
+
+        $changed = [];
+        foreach ($current as $field => $value) {
+            if (!array_key_exists($field, $this->arOriginal) || $this->arOriginal[$field] !== $value) {
+                $changed[$field] = $value;
+            }
+        }
+
+        if (empty($changed)) {
+            return 0;
+        }
+
+        $count = $this->crud
+            ->where(['id__eq' => $this->arOriginal['id']])
+            ->update($changed);
+
+        $this->arOriginal = array_merge($this->arOriginal, $changed);
+
+        return $count;
+    }
+
+    public function jsonSerialize(): array
+    {
+        $data = get_object_vars($this);
+        unset($data['crud'], $data['arOriginal']);
+        return $data;
+    }
+}

--- a/DBAL/EntityCastMiddleware.php
+++ b/DBAL/EntityCastMiddleware.php
@@ -76,13 +76,19 @@ class EntityCastMiddleware implements MiddlewareInterface
             return $crud->withMiddleware($this);
         }
         $class = $this->classes[$table];
-        $crud  = $crud->map(function (array $row) use ($class) {
+        $refCrud = null;
+        $crud  = $crud->map(function (array $row) use ($class, &$refCrud) {
             $obj = new $class();
             foreach ($row as $k => $v) {
                 $obj->$k = $v;
             }
+            if (in_array(ActiveRecordTrait::class, class_uses($obj))) {
+                $obj->initActiveRecord($refCrud, $row);
+            }
             return $obj;
         });
-        return $crud->withMiddleware($this);
+        $crud = $crud->withMiddleware($this);
+        $refCrud = $crud;
+        return $crud;
     }
 }

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -116,6 +116,31 @@ $record->title = 'New Title';
 $record->update();
 ```
 
+### Entity Classes and Bulk Insert
+```php
+class BookEntity {
+    use DBAL\ActiveRecordTrait;
+    public $id;
+    public $title;
+    public $author_id;
+}
+
+$caster = (new DBAL\EntityCastMiddleware())
+    ->register('books', BookEntity::class);
+$books = $caster->attach($books, 'books');
+
+$a = new BookEntity();
+$a->title = 'Book A';
+$a->author_id = 1;
+$b = new BookEntity();
+$b->title = 'Book B';
+$b->author_id = 2;
+$books->bulkInsertObjects([$a, $b]);
+
+$a->title = 'Updated';
+$a->update();
+```
+
 ## Cinema Ticketing
 This example manages movie screenings and reservations. It demonstrates altering tables and loading related screening information.
 

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -21,6 +21,30 @@ $crud = $caster->attach($crud, 'users');
 Relations defined with `#[HasOne]`, `#[HasMany]` or `#[BelongsTo]` on the class
 properties will be available for lazy or eager loading via `with()`.
 
+If the entity class uses `ActiveRecordTrait` the returned objects can be
+updated directly and new instances can be inserted:
+
+```php
+class UserEntity {
+    use DBAL\ActiveRecordTrait;
+    public $id;
+    public $name;
+}
+
+$crud = (new DBAL\Crud($pdo))->from('users');
+$crud = $caster->attach($crud, 'users');
+
+$user = iterator_to_array($crud->select())[0];
+$user->name = 'Bob';
+$user->update();
+
+$another = new UserEntity();
+$another->name = 'Alice';
+$crud->insertObject($another);
+```
+
+Multiple entities can also be inserted at once with `bulkInsertObjects()`.
+
 ## CacheMiddleware
 
 `CacheMiddleware` stores the rows returned by SELECT statements. By default it

--- a/tests/CrudObjectOperationsTest.php
+++ b/tests/CrudObjectOperationsTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\ActiveRecordTrait;
+
+class ItemEntity {
+    use ActiveRecordTrait;
+    public $id;
+    public $name;
+}
+
+class CrudObjectOperationsTest extends TestCase
+{
+    private function createPdo()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        return $pdo;
+    }
+
+    public function testInsertObjectAssignsIdAndAllowsUpdate()
+    {
+        $pdo = $this->createPdo();
+        $crud = (new Crud($pdo))->from('items');
+
+        $obj = new ItemEntity();
+        $obj->name = 'A';
+        $crud->insertObject($obj);
+
+        $this->assertEquals(1, $obj->id);
+        $obj->name = 'B';
+        $obj->update();
+
+        $rows = iterator_to_array($crud->select());
+        $this->assertEquals('B', $rows[0]['name']);
+    }
+
+    public function testBulkInsertObjectsInsertsAll()
+    {
+        $pdo = $this->createPdo();
+        $crud = (new Crud($pdo))->from('items');
+
+        $a = new ItemEntity();
+        $a->name = 'A';
+        $b = new ItemEntity();
+        $b->name = 'B';
+
+        $count = $crud->bulkInsertObjects([$a, $b]);
+        $this->assertEquals(2, $count);
+
+        $rows = iterator_to_array($crud->select());
+        $this->assertCount(2, $rows);
+    }
+}

--- a/tests/EntityCastActiveRecordTest.php
+++ b/tests/EntityCastActiveRecordTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\EntityCastMiddleware;
+use DBAL\ActiveRecordTrait;
+use DBAL\LazyRelation;
+use DBAL\Attributes\HasOne;
+
+class CastUserAr {
+    use ActiveRecordTrait;
+    public $id;
+    public $name;
+    #[HasOne('profiles', 'id', 'user_id')]
+    public $profile;
+}
+
+class EntityCastActiveRecordTest extends TestCase
+{
+    private function createPdo()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $pdo->exec('CREATE TABLE profiles (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, bio TEXT)');
+        $pdo->exec("INSERT INTO users (name) VALUES ('Alice')");
+        $pdo->exec("INSERT INTO profiles (user_id, bio) VALUES (1, 'bio')");
+        return $pdo;
+    }
+
+    public function testCastObjectsActAsActiveRecord()
+    {
+        $pdo = $this->createPdo();
+        $mw  = (new EntityCastMiddleware())->register('users', CastUserAr::class);
+        $crud = (new Crud($pdo))->from('users');
+        $crud = $mw->attach($crud, 'users');
+
+        $rows = iterator_to_array($crud->select());
+        $user = $rows[0];
+        $this->assertInstanceOf(CastUserAr::class, $user);
+        $this->assertInstanceOf(LazyRelation::class, $user->profile);
+
+        $user->name = 'Bob';
+        $user->update();
+
+        $rows = iterator_to_array($crud->select());
+        $this->assertEquals('Bob', $rows[0]->name);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ActiveRecordTrait` to let custom classes behave like active records
- extend `Crud` with `insertObject()` and `bulkInsertObjects()`
- let `EntityCastMiddleware` initialise entities using the trait
- document how to work with entity classes and bulk inserts
- add tests for new functionality

## Testing
- `composer test` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68683fb4ae84832cb79600e2c0c48b62