### PR TITLE
Introduce JoinType enum

### DIFF
--- a/DBAL/QueryBuilder/JoinType.php
+++ b/DBAL/QueryBuilder/JoinType.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+namespace DBAL\QueryBuilder;
+
+enum JoinType: string
+{
+        case INNER = 'INNER JOIN';
+        case LEFT  = 'LEFT JOIN';
+        case RIGHT = 'RIGHT JOIN';
+}

--- a/DBAL/QueryBuilder/Node/JoinNode.php
+++ b/DBAL/QueryBuilder/Node/JoinNode.php
@@ -4,6 +4,7 @@ namespace DBAL\QueryBuilder\Node;
 
 use DBAL\QueryBuilder\MessageInterface;
 use DBAL\QueryBuilder\Message;
+use DBAL\QueryBuilder\JoinType;
 
 /**
  * Node that builds SQL JOIN clauses.
@@ -15,28 +16,25 @@ use DBAL\QueryBuilder\Message;
  */
 class JoinNode extends NotImplementedNode
 {
-        const INNER_JOIN = 'INNER JOIN';
-        const LEFT_JOIN = 'LEFT JOIN';
-        const RIGHT_JOIN = 'RIGHT JOIN';
         /** @var bool */
         protected bool $isEmpty = false;
 
         /** @var string Table expression or name to join */
         protected string $table;
 
-        /** @var string Join type, one of the class constants */
-        protected string $type;
+        /** @var JoinType Join type */
+        protected JoinType $type;
 
         /** @var FilterNode[] Conditions used in the ON clause */
         protected array $on = [];
         /**
          * Constructor.
          *
-         * @param string              $table Table expression to join.
-         * @param string              $type  Join type, defaults to INNER_JOIN.
-         * @param array<int,FilterNode|array> $on List of conditions for the ON clause.
+         * @param string                    $table Table expression to join.
+         * @param JoinType                  $type  Join type, defaults to JoinType::INNER.
+         * @param array<int,FilterNode|array> $on  List of conditions for the ON clause.
          */
-        public function __construct($table, $type = JoinNode::INNER_JOIN, array $on = [])
+        public function __construct($table, JoinType $type = JoinType::INNER, array $on = [])
         {
                 $this->table = $table;
                 $this->type  = $type;
@@ -59,7 +57,7 @@ class JoinNode extends NotImplementedNode
          */
         public function send(MessageInterface $message)
         {
-                $msg = new Message($message->type(), sprintf('%s %s', $this->type, $this->table));
+                $msg = new Message($message->type(), sprintf('%s %s', $this->type->value, $this->table));
                 if (sizeof($this->on) > 0) {
                         $onMsg = new Message($message->type());
                         foreach ($this->on as $filter) {

--- a/DBAL/QueryBuilder/Query.php
+++ b/DBAL/QueryBuilder/Query.php
@@ -12,6 +12,7 @@ use DBAL\QueryBuilder\Node\FieldsNode;
 use DBAL\QueryBuilder\Node\FieldNode;
 use DBAL\QueryBuilder\Node\JoinsNode;
 use DBAL\QueryBuilder\Node\JoinNode;
+use DBAL\QueryBuilder\JoinType;
 use DBAL\QueryBuilder\Node\WhereNode;
 use DBAL\QueryBuilder\Node\HavingNode;
 use DBAL\QueryBuilder\Node\FilterNode;
@@ -45,13 +46,13 @@ class Query extends QueryNode
 	}
 /**
  * join
- * @param mixed $type
- * @param mixed $table
- * @param array $on
+ * @param JoinType $type
+ * @param mixed    $table
+ * @param array    $on
  * @return mixed
  */
 
-        protected function join($type, $table, array $on = [])
+        protected function join(JoinType $type, $table, array $on = [])
         {
                 $conditions = [];
                 foreach ($on as $filter) {
@@ -77,9 +78,9 @@ class Query extends QueryNode
         public function innerJoin($table, ...$on)
         {
                 $clone = clone $this;
-                $clone->join(JoinNode::INNER_JOIN, $table, $on);
+                $clone->join(JoinType::INNER, $table, $on);
                 return $clone;
-        }
+       }
 /**
  * leftJoin
  * @param mixed $table
@@ -90,9 +91,9 @@ class Query extends QueryNode
         public function leftJoin($table, ...$on)
         {
                 $clone = clone $this;
-                $clone->join(JoinNode::LEFT_JOIN, $table, $on);
+                $clone->join(JoinType::LEFT, $table, $on);
                 return $clone;
-        }
+       }
 /**
  * rightJoin
  * @param mixed $table
@@ -103,9 +104,9 @@ class Query extends QueryNode
         public function rightJoin($table, ...$on)
         {
                 $clone = clone $this;
-                $clone->join(JoinNode::RIGHT_JOIN, $table, $on);
+                $clone->join(JoinType::RIGHT, $table, $on);
                 return $clone;
-        }
+       }
 /**
  * where
  * @param mixed $...$filters


### PR DESCRIPTION
## Summary
- add `JoinType` enum for join types
- update `JoinNode` to use `JoinType`
- revise `Query` join helpers to pass the enum

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684b918778832cb864a74de3c12878