### PR TITLE
Add documentation for custom filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ $crud->where(['name__startWith' => 'Al']);
 SELECT * FROM users WHERE name LIKE 'Al%%';
 ```
 
+For additional examples of extending filters and hiding complex conditions see
+the [filters documentation](docs/filters.md).
+
 ### Grouping, ordering and limiting
 
 Use `group()` or `groupBy()` to add a `GROUP BY` clause. The `having()` method

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,6 +7,7 @@ DBAL is a lightweight Database Abstraction Layer written in PHP. It builds upon 
 * **integration.md** – examples of integrating DBAL with frameworks such as Slim and Lumen or plain PHP.
 * **examples.md** – practical use cases for book stores, cinemas and logistic APIs.
 * **hooks.md** – helper functions for quickly setting up middlewares.
+* **filters.md** – expanding filters and hiding complex conditions.
 * **twitter-tutorial.md** – building a microblogging platform example.
 
 - **Simple query builder**: compose SQL statements through a chainable API.
@@ -29,6 +30,7 @@ The documentation in this folder is organised into several topics:
 - **`integration.md`** – integration examples for Slim, Lumen and plain PHP usage.
 - **`examples.md`** – practical scenarios such as managing a book store, handling cinema tickets or implementing a logistics API.
 - **`lazy-relations.md`** – details the `LazyRelation` helper used for on-demand loading of related rows.
+- **`filters.md`** – extending filters and simplifying queries.
 
 Each file can be read in isolation, but together they provide a comprehensive guide to DBAL.
 


### PR DESCRIPTION
## Summary
- document advanced filter usage for custom operators
- reference the new docs from the overview and README

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684be5cf44832c9a6b832079ecf26b