### PR TITLE
Refine mixed docblocks

### DIFF
--- a/DBAL/ActiveRecord.php
+++ b/DBAL/ActiveRecord.php
@@ -24,8 +24,8 @@ class ActiveRecord implements \JsonSerializable
 
 /**
  * __call
- * @param mixed $name
- * @param mixed $arguments
+ * @param string $name
+ * @param array $arguments
  * @return mixed
  */
 
@@ -47,8 +47,8 @@ class ActiveRecord implements \JsonSerializable
 
 /**
  * __get
- * @param mixed $name
- * @return mixed
+ * @param string $name
+ * @return mixed|null
  */
 
     public function __get(string $name): mixed
@@ -60,9 +60,9 @@ class ActiveRecord implements \JsonSerializable
 
 /**
  * __set
- * @param mixed $name
+ * @param string $name
  * @param mixed $value
- * @return mixed
+ * @return void
  */
 
     public function __set(string $name, mixed $value): void
@@ -72,7 +72,7 @@ class ActiveRecord implements \JsonSerializable
 
 /**
  * update
- * @return mixed
+ * @return int
  */
 
     public function update(): int
@@ -104,7 +104,7 @@ class ActiveRecord implements \JsonSerializable
 
 /**
  * jsonSerialize
- * @return mixed
+ * @return array
  */
 
     public function jsonSerialize(): array

--- a/DBAL/Crud.php
+++ b/DBAL/Crud.php
@@ -131,7 +131,7 @@ class Crud extends Query
 
 /**
  * primaryTable
- * @return mixed
+ * @return string
  */
 
         private function primaryTable(): string
@@ -141,7 +141,7 @@ class Crud extends Query
 /**
  * runMiddlewares
  * @param MessageInterface $message
- * @return mixed
+ * @return void
  */
 
         protected function runMiddlewares(MessageInterface $message, float $time = null): void
@@ -160,8 +160,8 @@ class Crud extends Query
         }
 /**
  * collectRelations
- * @param mixed $table
- * @return mixed
+ * @param string $table
+ * @return array
  */
 
         private function collectRelations(string $table): array
@@ -254,7 +254,7 @@ class Crud extends Query
      * {@link CrudEventInterface} hooks are triggered.
      *
      * @param array $fields Associative array of column values to insert.
-     * @return mixed        The value returned by PDO::lastInsertId().
+ * @return string       The value returned by PDO::lastInsertId().
      */
 
         public function insert(array $fields): string

--- a/DBAL/GlobalFilterMiddleware.php
+++ b/DBAL/GlobalFilterMiddleware.php
@@ -32,7 +32,7 @@ class GlobalFilterMiddleware implements MiddlewareInterface
 
 /**
  * addFilter
- * @param mixed $table
+ * @param string|null $table
  * @param callable $filter
  * @return self
  */

--- a/DBAL/LinqMiddleware.php
+++ b/DBAL/LinqMiddleware.php
@@ -32,7 +32,7 @@ class LinqMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterfac
 /**
  * any
  * @param Crud $crud
- * @param mixed $...$filters
+ * @param mixed ...$filters
  * @return bool
  */
 
@@ -45,7 +45,7 @@ class LinqMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterfac
 /**
  * none
  * @param Crud $crud
- * @param mixed $...$filters
+ * @param mixed ...$filters
  * @return bool
  */
 
@@ -57,7 +57,7 @@ class LinqMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterfac
 /**
  * all
  * @param Crud $crud
- * @param mixed $...$filters
+ * @param mixed ...$filters
  * @return bool
  */
 
@@ -74,7 +74,7 @@ class LinqMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterfac
 /**
  * notAll
  * @param Crud $crud
- * @param mixed $...$filters
+ * @param mixed ...$filters
  * @return bool
  */
 
@@ -86,7 +86,7 @@ class LinqMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterfac
 /**
  * count
  * @param Crud $crud
- * @param mixed $...$filters
+ * @param mixed ...$filters
  * @return int
  */
 
@@ -114,7 +114,7 @@ class LinqMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterfac
  * max
  * @param Crud $crud
  * @param string $field
- * @return mixed
+ * @return mixed|null
  */
 
     public function max(Crud $crud, string $field)
@@ -128,7 +128,7 @@ class LinqMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterfac
  * min
  * @param Crud $crud
  * @param string $field
- * @return mixed
+ * @return mixed|null
  */
 
     public function min(Crud $crud, string $field)

--- a/DBAL/MemoryCacheStorage.php
+++ b/DBAL/MemoryCacheStorage.php
@@ -12,7 +12,7 @@ class MemoryCacheStorage implements CacheStorageInterface
 /**
  * get
  * @param string $key
- * @return mixed
+ * @return mixed|null
  */
 
     public function get(string $key)

--- a/DBAL/QueryBuilder/DynamicFilterBuilder.php
+++ b/DBAL/QueryBuilder/DynamicFilterBuilder.php
@@ -26,7 +26,7 @@ class DynamicFilterBuilder
 
 /**
  * current
- * @return mixed
+ * @return FilterNode
  */
 
        protected function current()
@@ -36,9 +36,9 @@ class DynamicFilterBuilder
 
 /**
  * __call
- * @param mixed $name
- * @param mixed $arguments
- * @return mixed
+ * @param string $name
+ * @param array $arguments
+ * @return self
  */
 
        public function __call($name, $arguments)
@@ -54,8 +54,8 @@ class DynamicFilterBuilder
 /**
  * group
  * @param callable $callback
- * @param mixed $operator
- * @return mixed
+ * @param string $operator
+ * @return self
  */
 
        protected function group(callable $callback, $operator)
@@ -72,7 +72,7 @@ class DynamicFilterBuilder
 /**
  * andGroup
  * @param callable $callback
- * @return mixed
+ * @return self
  */
 
        public function andGroup(callable $callback)
@@ -83,7 +83,7 @@ class DynamicFilterBuilder
 /**
  * orGroup
  * @param callable $callback
- * @return mixed
+ * @return self
  */
 
        public function orGroup(callable $callback)
@@ -93,7 +93,7 @@ class DynamicFilterBuilder
 
 /**
  * andNext
- * @return mixed
+ * @return self
  */
 
        public function andNext()
@@ -104,7 +104,7 @@ class DynamicFilterBuilder
 
 /**
  * orNext
- * @return mixed
+ * @return self
  */
 
        public function orNext()
@@ -115,7 +115,7 @@ class DynamicFilterBuilder
 
 /**
  * toNode
- * @return mixed
+ * @return FilterNode
  */
 
        public function toNode()
@@ -125,7 +125,7 @@ class DynamicFilterBuilder
 
 /**
  * toArray
- * @return mixed
+ * @return array
  */
 
        public function toArray()

--- a/DBAL/QueryBuilder/Message.php
+++ b/DBAL/QueryBuilder/Message.php
@@ -12,9 +12,9 @@ class Message implements MessageInterface
         protected array $values;
 /**
  * __construct
- * @param mixed $type
- * @param mixed $message
- * @param mixed $values
+ * @param int $type
+ * @param string $message
+ * @param array $values
  * @return void
  */
 
@@ -27,8 +27,8 @@ class Message implements MessageInterface
 /**
  * join
  * @param MessageInterface $message
- * @param mixed $separator
- * @return mixed
+ * @param string $separator
+ * @return self
  */
 
 	public function join(MessageInterface $message, $separator = MessageInterface::SEPARATOR_SPACE)
@@ -43,9 +43,9 @@ class Message implements MessageInterface
 	}
 /**
  * insertBefore
- * @param mixed $string
- * @param mixed $separator
- * @return mixed
+ * @param string $string
+ * @param string $separator
+ * @return self
  */
 
 	public function insertBefore($string, $separator = MessageInterface::SEPARATOR_SPACE)
@@ -59,9 +59,9 @@ class Message implements MessageInterface
 	}
 /**
  * replace
- * @param mixed $old
- * @param mixed $now
- * @return mixed
+ * @param string $old
+ * @param string $now
+ * @return self
  */
 
 	public function replace($old, $now)
@@ -72,9 +72,9 @@ class Message implements MessageInterface
 	}
 /**
  * insertAfter
- * @param mixed $string
- * @param mixed $separator
- * @return mixed
+ * @param string $string
+ * @param string $separator
+ * @return self
  */
 
 	public function insertAfter($string, $separator = MessageInterface::SEPARATOR_SPACE)
@@ -89,7 +89,7 @@ class Message implements MessageInterface
 /**
  * addValues
  * @param array $values
- * @return mixed
+ * @return self
  */
 
 	public function addValues(array $values)
@@ -100,7 +100,7 @@ class Message implements MessageInterface
 	}
 /**
  * getValues
- * @return mixed
+ * @return array
  */
 
 	public function getValues()
@@ -109,7 +109,7 @@ class Message implements MessageInterface
 	}
 /**
  * numValues
- * @return mixed
+ * @return int
  */
 
 	public function numValues()
@@ -118,7 +118,7 @@ class Message implements MessageInterface
 	}
 /**
  * getLength
- * @return mixed
+ * @return int
  */
 
 	public function getLength()
@@ -127,7 +127,7 @@ class Message implements MessageInterface
 	}
 /**
  * readMessage
- * @return mixed
+ * @return string
  */
 
 	public function readMessage()
@@ -136,7 +136,7 @@ class Message implements MessageInterface
 	}
 /**
  * type
- * @return mixed
+ * @return int
  */
 
 	public function type()

--- a/DBAL/QueryBuilder/Node/EmptyNode.php
+++ b/DBAL/QueryBuilder/Node/EmptyNode.php
@@ -13,7 +13,7 @@ class EmptyNode extends NotImplementedNode
 /**
  * send
  * @param MessageInterface $message
- * @return mixed
+ * @return MessageInterface
  */
 
 	public function send(MessageInterface $message)
@@ -22,7 +22,7 @@ class EmptyNode extends NotImplementedNode
 	}
 /**
  * isEmpty
- * @return mixed
+ * @return bool
  */
 
 	public function isEmpty()

--- a/DBAL/QueryBuilder/Node/NotImplementedNode.php
+++ b/DBAL/QueryBuilder/Node/NotImplementedNode.php
@@ -14,8 +14,8 @@ abstract class NotImplementedNode implements NodeInterface
 /**
  * appendChild
  * @param NodeInterface $node
- * @param mixed $name
- * @return mixed
+ * @param string|null $name
+ * @return string|null
  */
 
         public function appendChild(NodeInterface $node, $name = null)
@@ -24,8 +24,8 @@ abstract class NotImplementedNode implements NodeInterface
         }
 /**
  * hasChild
- * @param mixed $name
- * @return mixed
+ * @param string $name
+ * @return bool
  */
 
 	public function hasChild($name)
@@ -34,8 +34,8 @@ abstract class NotImplementedNode implements NodeInterface
 	}
 /**
  * getChild
- * @param mixed $name
- * @return mixed
+ * @param string $name
+ * @return NodeInterface
  */
 
 	public function getChild($name)
@@ -44,8 +44,8 @@ abstract class NotImplementedNode implements NodeInterface
 	}
 /**
  * removeChild
- * @param mixed $name
- * @return mixed
+ * @param string $name
+ * @return NodeInterface
  */
 
 	public function removeChild($name)
@@ -54,7 +54,7 @@ abstract class NotImplementedNode implements NodeInterface
 	}
 /**
  * allChildren
- * @return mixed
+ * @return array
  */
 
 	public function allChildren()
@@ -63,7 +63,7 @@ abstract class NotImplementedNode implements NodeInterface
 	}
 /**
  * isEmpty
- * @return mixed
+ * @return bool
  */
 
 	public function isEmpty()

--- a/DBAL/QueryBuilder/Query.php
+++ b/DBAL/QueryBuilder/Query.php
@@ -28,8 +28,8 @@ class Query extends QueryNode
 {
 /**
  * from
- * @param mixed $...$tables
- * @return mixed
+ * @param string|TableNode ...$tables
+ * @return self
  */
 
 	public function from(...$tables)
@@ -45,10 +45,10 @@ class Query extends QueryNode
 	}
 /**
  * join
- * @param mixed $type
- * @param mixed $table
- * @param array $on
- * @return mixed
+ * @param string $type
+ * @param string|TableNode $table
+ * @param array<int,FilterNode|array|callable> $on
+ * @return void
  */
 
         protected function join($type, $table, array $on = [])
@@ -69,9 +69,9 @@ class Query extends QueryNode
         }
 /**
  * innerJoin
- * @param mixed $table
- * @param mixed $...$on
- * @return mixed
+ * @param string|TableNode $table
+ * @param mixed ...$on
+ * @return self
  */
 
         public function innerJoin($table, ...$on)
@@ -82,9 +82,9 @@ class Query extends QueryNode
         }
 /**
  * leftJoin
- * @param mixed $table
- * @param mixed $...$on
- * @return mixed
+ * @param string|TableNode $table
+ * @param mixed ...$on
+ * @return self
  */
 
         public function leftJoin($table, ...$on)
@@ -95,9 +95,9 @@ class Query extends QueryNode
         }
 /**
  * rightJoin
- * @param mixed $table
- * @param mixed $...$on
- * @return mixed
+ * @param string|TableNode $table
+ * @param mixed ...$on
+ * @return self
  */
 
         public function rightJoin($table, ...$on)
@@ -108,8 +108,8 @@ class Query extends QueryNode
         }
 /**
  * where
- * @param mixed $...$filters
- * @return mixed
+ * @param mixed ...$filters
+ * @return self
  */
 
         public function where(...$filters)
@@ -137,8 +137,8 @@ class Query extends QueryNode
         }
 /**
  * having
- * @param array $...$filters
- * @return mixed
+ * @param array ...$filters
+ * @return self
  */
 
 	public function having(array ...$filters)
@@ -150,8 +150,8 @@ class Query extends QueryNode
 	}
 /**
  * group
- * @param mixed $...$fields
- * @return mixed
+ * @param mixed ...$fields
+ * @return self
  */
 
         public function group(...$fields)
@@ -163,8 +163,8 @@ class Query extends QueryNode
         }
 /**
  * groupBy
- * @param mixed $...$fields
- * @return mixed
+ * @param mixed ...$fields
+ * @return self
  */
 
         public function groupBy(...$fields)
@@ -174,9 +174,9 @@ class Query extends QueryNode
         }
 /**
  * order
- * @param mixed $type
+ * @param string $type
  * @param array $fields
- * @return mixed
+ * @return self
  */
 
         public function order($type, array $fields)
@@ -188,8 +188,8 @@ class Query extends QueryNode
 	}
 /**
  * desc
- * @param mixed $...$fields
- * @return mixed
+ * @param mixed ...$fields
+ * @return self
  */
 
 	public function desc(...$fields)
@@ -199,8 +199,8 @@ class Query extends QueryNode
 	}
 /**
  * asc
- * @param mixed $...$fields
- * @return mixed
+ * @param mixed ...$fields
+ * @return self
  */
 
 	public function asc(...$fields)
@@ -210,8 +210,8 @@ class Query extends QueryNode
 	}
 /**
  * limit
- * @param mixed $limit
- * @return mixed
+ * @param int $limit
+ * @return self
  */
 
 	public function limit($limit)
@@ -222,8 +222,8 @@ class Query extends QueryNode
 	}
 /**
  * offset
- * @param mixed $offset
- * @return mixed
+ * @param int $offset
+ * @return self
  */
 
 	public function offset($offset)
@@ -234,8 +234,8 @@ class Query extends QueryNode
 	}
 /**
  * buildSelect
- * @param mixed $...$fields
- * @return mixed
+ * @param mixed ...$fields
+ * @return MessageInterface
  */
 
 	public function buildSelect(...$fields)
@@ -261,7 +261,7 @@ class Query extends QueryNode
 /**
  * buildInsert
  * @param array $fields
- * @return mixed
+ * @return MessageInterface
  */
 
         public function buildInsert(array $fields)
@@ -275,7 +275,7 @@ class Query extends QueryNode
 /**
  * buildBulkInsert
  * @param array $rows
- * @return mixed
+ * @return MessageInterface
  */
 
         public function buildBulkInsert(array $rows)
@@ -289,7 +289,7 @@ class Query extends QueryNode
 /**
  * buildUpdate
  * @param array $fields
- * @return mixed
+ * @return MessageInterface
  */
 
         public function buildUpdate(array $fields)

--- a/DBAL/ResultGenerator.php
+++ b/DBAL/ResultGenerator.php
@@ -85,11 +85,11 @@ class ResultGenerator
 
 /**
  * applyMappers
- * @param mixed $row
- * @return mixed
+ * @param array $row
+ * @return array
  */
 
-    private function applyMappers($row)
+    private function applyMappers(array $row)
     {
         foreach ($this->mappers as $mapper) {
             $row = $mapper($row);
@@ -99,11 +99,11 @@ class ResultGenerator
 
 /**
  * applyLazyRelations
- * @param mixed $row
- * @return mixed
+ * @param array $row
+ * @return array
  */
 
-    private function applyLazyRelations($row)
+    private function applyLazyRelations(array $row)
     {
         foreach ($this->relations as $name => $rel) {
             if (in_array($name, $this->eagerRelations)) {

--- a/DBAL/ResultIterator.php
+++ b/DBAL/ResultIterator.php
@@ -125,7 +125,7 @@ class ResultIterator implements \Iterator, \JsonSerializable
         }
 /**
  * rewind
- * @return mixed
+ * @return array
  */
 
         #[\ReturnTypeWillChange]
@@ -169,7 +169,7 @@ class ResultIterator implements \Iterator, \JsonSerializable
         }
 /**
  * valid
- * @return mixed
+ * @return array
  */
 
         #[\ReturnTypeWillChange]
@@ -243,8 +243,8 @@ class ResultIterator implements \Iterator, \JsonSerializable
 
 /**
  * groupBy
- * @param mixed $key
- * @return mixed
+ * @param string|callable $key
+ * @return array
  */
 
         public function groupBy($key)

--- a/DBAL/SqliteCacheStorage.php
+++ b/DBAL/SqliteCacheStorage.php
@@ -27,7 +27,7 @@ class SqliteCacheStorage implements CacheStorageInterface
 /**
  * get
  * @param string $key
- * @return mixed
+ * @return mixed|null
  */
 
     public function get(string $key)


### PR DESCRIPTION
## Summary
- annotate cache storages with mixed|null return types
- clarify parameter types for GlobalFilterMiddleware
- correct docblocks for ActiveRecord, Crud and iterator classes
- tighten types across the query builder

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68684b9d99a8832cabdba1c6c74b4702