### PR TITLE
Enhance DBAL helpers with LINQ and Rx utilities

### DIFF
--- a/DBAL/LinqMiddleware.php
+++ b/DBAL/LinqMiddleware.php
@@ -151,4 +151,30 @@ class LinqMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterfac
         $rows = iterator_to_array($crud->select("SUM($field) AS s"));
         return (float)($rows[0]['s'] ?? 0);
     }
+
+    /**
+     * average
+     * @param Crud $crud
+     * @param string $field
+     * @return float
+     */
+    public function average(Crud $crud, string $field): float
+    {
+        $field = $this->quoteIdentifier($field);
+        $rows = iterator_to_array($crud->select("AVG($field) AS a"));
+        return (float)($rows[0]['a'] ?? 0);
+    }
+
+    /**
+     * distinct
+     * @param Crud $crud
+     * @param string $field
+     * @return array
+     */
+    public function distinct(Crud $crud, string $field): array
+    {
+        $field = $this->quoteIdentifier($field);
+        $rows = iterator_to_array($crud->select("DISTINCT $field AS d"));
+        return array_map(fn($r) => $r['d'], $rows);
+    }
 }

--- a/DBAL/QueryBuilder/Query.php
+++ b/DBAL/QueryBuilder/Query.php
@@ -215,12 +215,22 @@ class Query extends QueryNode
  * @return mixed
  */
 
-	public function limit($limit)
-	{
-		$clone = clone $this;
-		$clone->getChild('limit')->setLimit($limit);
-		return $clone;
-	}
+    public function limit($limit)
+    {
+        $clone = clone $this;
+        $clone->getChild('limit')->setLimit($limit);
+        return $clone;
+    }
+
+    /**
+     * take
+     * @param int $limit
+     * @return mixed
+     */
+    public function take(int $limit)
+    {
+        return $this->limit($limit);
+    }
 /**
  * offset
  * @param mixed $offset
@@ -230,9 +240,19 @@ class Query extends QueryNode
 	public function offset($offset)
 	{
 		$clone = clone $this;
-		$clone->getChild('limit')->setOffset($offset);
-		return $clone;
-	}
+        $clone->getChild('limit')->setOffset($offset);
+        return $clone;
+    }
+
+    /**
+     * skip
+     * @param int $offset
+     * @return mixed
+     */
+    public function skip(int $offset)
+    {
+        return $this->offset($offset);
+    }
 /**
  * buildSelect
  * @param mixed $...$fields

--- a/DBAL/RxMiddleware.php
+++ b/DBAL/RxMiddleware.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+use Generator;
+
+/**
+ * Middleware providing RxJS-like helpers for streams.
+ */
+class RxMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterface
+{
+    public function __invoke(MessageInterface $msg): void
+    {
+        // no-op
+    }
+
+    /**
+     * Apply a mapping function to each yielded row.
+     */
+    public function map(Crud $crud, callable $fn, ...$fields): Generator
+    {
+        foreach ($crud->stream(...$fields) as $row) {
+            yield $fn($row);
+        }
+    }
+
+    /**
+     * Yield only rows that satisfy the predicate.
+     */
+    public function filter(Crud $crud, callable $fn, ...$fields): Generator
+    {
+        foreach ($crud->stream(...$fields) as $row) {
+            if ($fn($row)) {
+                yield $row;
+            }
+        }
+    }
+
+    /**
+     * Reduce all rows into a single value.
+     */
+    public function reduce(Crud $crud, callable $fn, $initial = null, ...$fields)
+    {
+        $acc = $initial;
+        foreach ($crud->stream(...$fields) as $row) {
+            $acc = $fn($acc, $row);
+        }
+        return $acc;
+    }
+
+    /**
+     * Debounce results by delaying each yield in milliseconds.
+     */
+    public function debounce(Crud $crud, int $ms, ...$fields): Generator
+    {
+        foreach ($crud->stream(...$fields) as $row) {
+            usleep($ms * 1000);
+            yield $row;
+        }
+    }
+
+    /**
+     * Execute an operation catching any errors.
+     */
+    public function catchError(callable $operation, callable $handler)
+    {
+        try {
+            return $operation();
+        } catch (\Throwable $e) {
+            return $handler($e);
+        }
+    }
+
+    /**
+     * Retry an operation the given number of times.
+     */
+    public function retry(callable $operation, int $times = 1, int $delayMs = 0)
+    {
+        $attempts = 0;
+        while (true) {
+            try {
+                return $operation();
+            } catch (\Throwable $e) {
+                $attempts++;
+                if ($attempts > $times) {
+                    throw $e;
+                }
+                if ($delayMs > 0) {
+                    usleep($delayMs * 1000);
+                }
+            }
+        }
+    }
+
+    /**
+     * Merge multiple generators into one sequence.
+     */
+    public function merge(Generator ...$gens): Generator
+    {
+        foreach ($gens as $gen) {
+            foreach ($gen as $row) {
+                yield $row;
+            }
+        }
+    }
+
+    /**
+     * Concatenate generators sequentially.
+     */
+    public function concat(Generator ...$gens): Generator
+    {
+        foreach ($gens as $gen) {
+            foreach ($gen as $row) {
+                yield $row;
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A lightweight Database Abstraction Layer for PHP.
 - Attribute based entity validation and relation definition
 - Relation loader middleware for programmatic relations ([docs](docs/middlewares.md#relationloadermiddleware))
 - First/Last and Linq helpers
+- Rx-style stream utilities
 - ActiveRecord objects for tracked updates
 - Development error pages and global filters
 
@@ -159,8 +160,8 @@ the [filters documentation](docs/filters.md).
 
 Use `group()` or `groupBy()` to add a `GROUP BY` clause. The `having()` method
 lets you filter aggregated results. Ordering can be controlled with `order()`,
-`asc()` or `desc()`, while `limit()` and `offset()` constrain the amount of
-rows returned.
+`asc()` or `desc()`, while `limit()`/`take()` and `offset()`/`skip()`
+constrain the amount of rows returned.
 
 ```php
 $rows = $crud
@@ -216,8 +217,8 @@ $page    = 2;
 $perPage = 20;
 
 $rows = $crud
-    ->limit($perPage)
-    ->offset(($page - 1) * $perPage)
+    ->take($perPage)
+    ->skip(($page - 1) * $perPage)
     ->select();
 ```
 ```sql
@@ -229,7 +230,8 @@ SELECT * FROM users LIMIT 20 OFFSET 20;
 `Crud::stream()` returns a generator that yields each row lazily. A callback can
 be provided to process rows as they are produced. See the
 [ResultIterator documentation](docs/overview.md#resultiterator) for details on
-grouping results and exporting them to JSON.
+grouping results and exporting them to JSON. The optional `RxMiddleware`
+offers `map()`, `filter()` and other helpers to transform the stream.
 
 ```php
 $generator = $crud->stream('id', 'name');

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -156,6 +156,20 @@ Adds helper methods for quick queries:
 - `max($field)` returns the maximum value of the given field.
 - `min($field)` returns the minimum value of the given field.
 - `sum($field)` returns the sum of the values in the given field.
+- `average($field)` returns the average value of the given field.
+- `distinct($field)` returns an array with the distinct values of the field.
+
+## RxMiddleware
+Adds helpers inspired by RxJS:
+
+- `map($crud, callable $fn, ...$fields)` applies a transformation to each row.
+- `filter($crud, callable $fn, ...$fields)` yields only matching rows.
+- `reduce($crud, callable $fn, $initial, ...$fields)` aggregates rows into a single value.
+- `debounce($crud, $ms, ...$fields)` delays each yielded row by the given milliseconds.
+- `catchError(callable $op, callable $handler)` executes `$op` and passes any error to `$handler`.
+- `retry(callable $op, $times, $delayMs)` retries `$op` if it throws an exception.
+- `merge(...$generators)` merges multiple generators.
+- `concat(...$generators)` concatenates generators sequentially.
 
 ## EntityValidationMiddleware
 Provides a fluent API to validate data and declare relations for eager or lazy loading.

--- a/tests/LinqMiddlewareTest.php
+++ b/tests/LinqMiddlewareTest.php
@@ -57,6 +57,8 @@ class LinqMiddlewareTest extends TestCase
         $this->assertEquals(3, $crud->max('id'));
         $this->assertEquals(1, $crud->min('id'));
         $this->assertEquals(6.0, $crud->sum('id'));
+        $this->assertEquals(2.0, $crud->average('id'));
+        $this->assertEquals([1,2,3], $crud->distinct('id'));
     }
 
     public function testCount()

--- a/tests/QueryAliasesTest.php
+++ b/tests/QueryAliasesTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+
+class QueryAliasesTest extends TestCase
+{
+    public function testTakeAndSkipAliases()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $pdo->exec('INSERT INTO t(name) VALUES ("A"),("B"),("C")');
+
+        $crud = (new Crud($pdo))->from('t');
+        $rows = iterator_to_array($crud->take(2)->skip(1)->select('name'));
+        $this->assertEquals([['name' => 'B'], ['name' => 'C']], $rows);
+    }
+}

--- a/tests/RxMiddlewareTest.php
+++ b/tests/RxMiddlewareTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\RxMiddleware;
+
+class RxMiddlewareTest extends TestCase
+{
+    private function createCrud()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, val INTEGER)');
+        $pdo->exec('INSERT INTO items(val) VALUES (1),(2),(3)');
+        $mw = new RxMiddleware();
+        $crud = (new Crud($pdo))->from('items')->withMiddleware($mw);
+        return [$crud, $mw];
+    }
+
+    public function testMapFilterReduce()
+    {
+        [$crud, $rx] = $this->createCrud();
+        $mapped = iterator_to_array($rx->map($crud, fn($r) => $r['val'] * 2));
+        $this->assertEquals([2,4,6], $mapped);
+
+        $filtered = iterator_to_array($rx->filter($crud, fn($r) => $r['val'] > 1));
+        $this->assertCount(2, $filtered);
+
+        $sum = $rx->reduce($crud, fn($acc, $r) => $acc + $r['val'], 0);
+        $this->assertEquals(6, $sum);
+    }
+
+    public function testMergeConcat()
+    {
+        [$crud, $rx] = $this->createCrud();
+        $g1 = $crud->stream();
+        $g2 = $crud->stream();
+        $merged = iterator_to_array($rx->merge($g1, $g2));
+        $this->assertCount(6, $merged);
+
+        $concat = iterator_to_array($rx->concat($crud->stream(), $crud->stream()));
+        $this->assertCount(6, $concat);
+    }
+}


### PR DESCRIPTION
## Summary
- extend `LinqMiddleware` with `average()` and `distinct()` helpers
- add `take()` and `skip()` aliases in the query builder
- introduce `RxMiddleware` for stream transformation
- document new middleware and updated examples
- cover new helpers with unit tests

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684c54dc30832caff728d363dc607b