### PR TITLE
Add CustomFilterBuilder example

### DIFF
--- a/DBAL/QueryBuilder/CustomFilterBuilder.php
+++ b/DBAL/QueryBuilder/CustomFilterBuilder.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace DBAL\QueryBuilder;
+
+/**
+ * Example extension of DynamicFilterBuilder with domain specific helpers.
+ */
+class CustomFilterBuilder extends DynamicFilterBuilder
+{
+    /**
+     * Adds the condition gender__eq('fem').
+     */
+    public function isWoman(): self
+    {
+        parent::__call('gender__eq', ['fem']);
+        return $this;
+    }
+}

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -78,3 +78,33 @@ $case = (new CaseNode())
 // SELECT CASE WHEN status = 1 THEN 'active' WHEN status = 0 THEN 'inactive' ELSE 'unknown' END AS state FROM users
 ```
 
+
+## Custom filter builders
+
+Dynamic methods can be tailored to your domain by extending `DynamicFilterBuilder`:
+
+```php
+use DBAL\QueryBuilder\CustomFilterBuilder;
+
+$rows = $crud->where(function (CustomFilterBuilder $q) {
+    $q->isWoman()->andNext()->status__eq('active');
+})->select('id', 'name');
+```
+
+The `CustomFilterBuilder` class can define helpers that map to one or more
+filters. For example:
+
+```php
+class CustomFilterBuilder extends DynamicFilterBuilder
+{
+    public function isWoman(): self
+    {
+        parent::__call('gender__eq', ['fem']);
+        return $this;
+    }
+}
+```
+
+```sql
+SELECT id, name FROM users WHERE gender = 'fem' AND status = 'active';
+```

--- a/tests/CustomFilterBuilderTest.php
+++ b/tests/CustomFilterBuilderTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use DBAL\QueryBuilder\CustomFilterBuilder;
+
+class CustomFilterBuilderTest extends TestCase
+{
+    public function testCustomMethod()
+    {
+        $builder = new CustomFilterBuilder();
+        $builder->isWoman()->age__gt(18);
+        $this->assertEquals([
+            'gender__eq' => 'fem',
+            'age__gt'    => 18,
+        ], $builder->toArray());
+    }
+}


### PR DESCRIPTION
## Summary
- extend DynamicFilterBuilder via new `CustomFilterBuilder`
- demonstrate custom builder usage in documentation
- add PHPUnit test for the new class

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686853a8a900832cb08389dd12e42b17