### PR TITLE
Add platform abstraction for SQL dialects

### DIFF
--- a/DBAL/Crud.php
+++ b/DBAL/Crud.php
@@ -29,9 +29,9 @@ class Crud extends Query
      * @param \PDO $connection Database connection used for all queries.
      */
 
-        public function __construct(protected \PDO $connection)
+        public function __construct(protected \PDO $connection, ?\DBAL\Platform\PlatformInterface $platform = null)
         {
-                parent::__construct();
+                parent::__construct($platform);
         }
     /**
      * Registers a mapper callback to transform each fetched row.

--- a/DBAL/Platform/PlatformInterface.php
+++ b/DBAL/Platform/PlatformInterface.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+namespace DBAL\Platform;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+/**
+ * Interface for database platform specific SQL variations.
+ */
+interface PlatformInterface
+{
+    /**
+     * Apply LIMIT and OFFSET clauses to the SQL message.
+     */
+    public function applyLimitOffset(MessageInterface $message, ?int $limit, ?int $offset): MessageInterface;
+
+    /**
+     * Keyword used to mark auto-increment columns in CREATE TABLE statements.
+     */
+    public function autoIncrementKeyword(): string;
+}

--- a/DBAL/Platform/PostgresPlatform.php
+++ b/DBAL/Platform/PostgresPlatform.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+namespace DBAL\Platform;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+/**
+ * PostgreSQL specific SQL dialect implementation.
+ */
+class PostgresPlatform implements PlatformInterface
+{
+    public function applyLimitOffset(MessageInterface $message, ?int $limit, ?int $offset): MessageInterface
+    {
+        if ($limit === null && $offset === null) {
+            return $message;
+        } elseif ($limit !== null && $offset === null) {
+            return $message->addValues([$limit])->insertAfter('LIMIT ?');
+        } elseif ($limit === null && $offset !== null) {
+            return $message->addValues([$offset])->insertAfter('OFFSET ?');
+        } else {
+            return $message->addValues([$limit, $offset])->insertAfter('LIMIT ? OFFSET ?');
+        }
+    }
+
+    public function autoIncrementKeyword(): string
+    {
+        return 'SERIAL';
+    }
+}

--- a/DBAL/Platform/SqlServerPlatform.php
+++ b/DBAL/Platform/SqlServerPlatform.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+namespace DBAL\Platform;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+/**
+ * SQL Server specific SQL dialect implementation.
+ */
+class SqlServerPlatform implements PlatformInterface
+{
+    public function applyLimitOffset(MessageInterface $message, ?int $limit, ?int $offset): MessageInterface
+    {
+        if ($limit === null && $offset === null) {
+            return $message;
+        }
+
+        $off = $offset ?? 0;
+        $values = [$off];
+        $sql = 'OFFSET ? ROWS';
+        if ($limit !== null) {
+            $sql .= ' FETCH NEXT ? ROWS ONLY';
+            $values[] = $limit;
+        }
+        return $message->addValues($values)->insertAfter($sql);
+    }
+
+    public function autoIncrementKeyword(): string
+    {
+        return 'IDENTITY(1,1)';
+    }
+}

--- a/DBAL/Platform/SqlitePlatform.php
+++ b/DBAL/Platform/SqlitePlatform.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+namespace DBAL\Platform;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+/**
+ * SQLite specific SQL dialect implementation.
+ */
+class SqlitePlatform implements PlatformInterface
+{
+    public function applyLimitOffset(MessageInterface $message, ?int $limit, ?int $offset): MessageInterface
+    {
+        if ($limit === null && $offset === null) {
+            return $message;
+        } elseif ($limit !== null && $offset === null) {
+            return $message->addValues([$limit])->insertAfter('LIMIT ?');
+        } elseif ($limit === null && $offset !== null) {
+            return $message->addValues([$offset])->insertAfter('LIMIT -1 OFFSET ?');
+        } else {
+            return $message->addValues([$limit, $offset])->insertAfter('LIMIT ? OFFSET ?');
+        }
+    }
+
+    public function autoIncrementKeyword(): string
+    {
+        return 'AUTOINCREMENT';
+    }
+}

--- a/DBAL/QueryBuilder/Node/QueryNode.php
+++ b/DBAL/QueryBuilder/Node/QueryNode.php
@@ -5,6 +5,8 @@ namespace DBAL\QueryBuilder\Node;
 use DBAL\QueryBuilder\MessageInterface;
 use DBAL\QueryBuilder\Message;
 use DBAL\QueryBuilder\NodeInterface;
+use DBAL\Platform\PlatformInterface;
+use DBAL\Platform\SqlitePlatform;
 
 /**
  * Root node for building complete SQL queries.
@@ -16,21 +18,20 @@ class QueryNode extends Node
 {
         /** @var bool */
         protected bool $isEmpty = false;
-        /**
-         * Initialize all child nodes used to build queries.
-         */
-        public function __construct()
+
+        public function __construct(private ?PlatformInterface $platform = null)
         {
-		$this->appendChild(new TablesNode, 'tables');
-		$this->appendChild(new FieldsNode, 'fields');
-		$this->appendChild(new JoinsNode, 'joins');
-		$this->appendChild(new WhereNode, 'where');
-		$this->appendChild(new HavingNode, 'having');
-		$this->appendChild(new GroupNode, 'group');
-		$this->appendChild(new OrderNode, 'order');
-		$this->appendChild(new LimitNode, 'limit');
-		$this->appendChild(new ChangeNode, 'change');
-	}
+                $this->platform = $this->platform ?? new SqlitePlatform();
+                $this->appendChild(new TablesNode, 'tables');
+                $this->appendChild(new FieldsNode, 'fields');
+                $this->appendChild(new JoinsNode, 'joins');
+                $this->appendChild(new WhereNode, 'where');
+                $this->appendChild(new HavingNode, 'having');
+                $this->appendChild(new GroupNode, 'group');
+                $this->appendChild(new OrderNode, 'order');
+                $this->appendChild(new LimitNode($this->platform), 'limit');
+                $this->appendChild(new ChangeNode, 'change');
+        }
         /**
          * Generate the SQL for the configured query type.
          */

--- a/DBAL/QueryBuilder/Query.php
+++ b/DBAL/QueryBuilder/Query.php
@@ -28,6 +28,10 @@ use DBAL\QueryBuilder\DynamicFilterBuilder;
  */
 class Query extends QueryNode
 {
+        public function __construct(?\DBAL\Platform\PlatformInterface $platform = null)
+        {
+                parent::__construct($platform);
+        }
 /**
  * from
  * @param string|TableNode ...$tables

--- a/DBAL/Schema/SchemaColumnBuilder.php
+++ b/DBAL/Schema/SchemaColumnBuilder.php
@@ -2,6 +2,8 @@
 declare(strict_types=1);
 namespace DBAL\Schema;
 
+use DBAL\Platform\PlatformInterface;
+
 /**
  * Clase/Interfaz SchemaColumnBuilder
  */
@@ -16,7 +18,7 @@ class SchemaColumnBuilder
  * @return void
  */
 
-    public function __construct(private string $name)
+    public function __construct(private string $name, private PlatformInterface $platform)
     {    }
 
 /**
@@ -79,7 +81,7 @@ class SchemaColumnBuilder
 
     public function autoIncrement(): self
     {
-        $this->constraints[] = 'AUTOINCREMENT';
+        $this->constraints[] = $this->platform->autoIncrementKeyword();
         return $this;
     }
 

--- a/DBAL/Schema/SchemaTableBuilder.php
+++ b/DBAL/Schema/SchemaTableBuilder.php
@@ -2,6 +2,8 @@
 declare(strict_types=1);
 namespace DBAL\Schema;
 
+use DBAL\Platform\PlatformInterface;
+
 /**
  * Clase/Interfaz SchemaTableBuilder
  */
@@ -16,7 +18,7 @@ class SchemaTableBuilder
  * @return void
  */
 
-    public function __construct(private string $name)
+    public function __construct(private string $name, private PlatformInterface $platform)
     {    }
 
 /**
@@ -40,7 +42,7 @@ class SchemaTableBuilder
 
     public function addColumn(string $name, $typeOrCallback): self
     {
-        $builder = new SchemaColumnBuilder($name);
+        $builder = new SchemaColumnBuilder($name, $this->platform);
         if (is_callable($typeOrCallback)) {
             $typeOrCallback($builder);
         } else {

--- a/tests/LimitNodeTest.php
+++ b/tests/LimitNodeTest.php
@@ -3,12 +3,13 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\QueryBuilder\Message;
 use DBAL\QueryBuilder\Node\LimitNode;
+use DBAL\Platform\SqlitePlatform;
 
 class LimitNodeTest extends TestCase
 {
     public function testLimitAndOffset()
     {
-        $node = new LimitNode();
+        $node = new LimitNode(new SqlitePlatform());
         $node->setLimit(10);
         $node->setOffset(5);
         $msg = $node->send(new Message());
@@ -18,7 +19,7 @@ class LimitNodeTest extends TestCase
 
     public function testOnlyLimit()
     {
-        $node = new LimitNode();
+        $node = new LimitNode(new SqlitePlatform());
         $node->setLimit(3);
         $msg = $node->send(new Message());
         $this->assertEquals('LIMIT ?', $msg->readMessage());

--- a/tests/SchemaTableBuilderTest.php
+++ b/tests/SchemaTableBuilderTest.php
@@ -2,12 +2,13 @@
 declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\Schema\SchemaTableBuilder;
+use DBAL\Platform\SqlitePlatform;
 
 class SchemaTableBuilderTest extends TestCase
 {
     public function testLambdaColumnDefinition()
     {
-        $table = new SchemaTableBuilder('users');
+        $table = new SchemaTableBuilder('users', new SqlitePlatform());
         $table->column('id', function ($c) {
             $c->integer()->primaryKey()->autoIncrement();
         });
@@ -22,7 +23,7 @@ class SchemaTableBuilderTest extends TestCase
 
     public function testAddColumnWithStringType()
     {
-        $table = new SchemaTableBuilder('items');
+        $table = new SchemaTableBuilder('items', new SqlitePlatform());
         $table->addColumn('id', function ($c) {
             $c->integer()->primaryKey();
         });
@@ -35,7 +36,7 @@ class SchemaTableBuilderTest extends TestCase
 
     public function testColumnWithStringType()
     {
-        $table = new SchemaTableBuilder('products');
+        $table = new SchemaTableBuilder('products', new SqlitePlatform());
         $table->column('id', 'INTEGER');
         $table->column('name', 'TEXT');
         $this->assertEquals(
@@ -46,7 +47,7 @@ class SchemaTableBuilderTest extends TestCase
 
     public function testAddColumnAfterBuild()
     {
-        $table = new SchemaTableBuilder('logs');
+        $table = new SchemaTableBuilder('logs', new SqlitePlatform());
         $table->column('id', 'INTEGER');
         $this->assertEquals(
             'CREATE TABLE logs (id INTEGER)',


### PR DESCRIPTION
## Summary
- introduce `PlatformInterface` and platform implementations for SQLite, PostgreSQL and SQL Server
- allow `QueryNode`/`Query`/`Crud` to accept a platform object
- adapt `LimitNode` to delegate LIMIT/OFFSET generation to the selected platform
- make schema builders aware of the platform for auto increment keyword
- update unit tests accordingly

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868531ec178832c922073b6d1c20d9f