### PR TITLE
Add engine support docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A lightweight Database Abstraction Layer for PHP.
 - Lazy and eager loading of relations
 - Middleware system with caching, transactions, validation and more
 - Schema builder and migration helpers
+- Platform classes for SQLite, PostgreSQL and SQL Server
 - Attribute based entity validation and relation definition
 - Relation loader middleware for programmatic relations ([docs](docs/middlewares.md#relationloadermiddleware))
 - First/Last and Linq helpers
@@ -40,6 +41,16 @@ $crud = (new DBAL\Crud($pdo))->from('users');
 ```
 ```sql
 SELECT * FROM users;
+```
+
+## Database Engines
+
+DBAL relies solely on PDO, so it can connect to any engine with a PDO driver. It includes platform classes for SQLite, PostgreSQL and SQL Server. Use the appropriate platform when creating a `Crud` instance:
+
+```php
+use DBAL\Platform\PostgresPlatform;
+
+$crud = new DBAL\Crud($pdo, new PostgresPlatform());
 ```
 
 ### Insert records
@@ -630,6 +641,7 @@ DBAL is primarily intended for building microservices, powering small scripts an
 These example domains are merely illustrative—developers are free to decide where and how to apply the library.
 
 DBAL integrates easily with minimal frameworks like Slim and Lumen or even plain PHP scripts. Additional examples, including a microblogging tutorial, can be found in the [docs](docs/) folder.
+For database specific notes see [`docs/engines.md`](docs/engines.md).
 
 ## Bookstore example
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -1,0 +1,75 @@
+# Supported Database Engines
+
+DBAL uses PHP's PDO extension as its only dependency. This means it can work with any database that has a PDO driver available. The library ships with platform classes for some engines to handle SQL differences like `LIMIT` syntax and auto‑increment keywords.
+
+## Built‑in Platforms
+
+- **SQLite** (`SqlitePlatform`) – Default behaviour when no platform is passed. It understands SQLite's `LIMIT` syntax and uses `AUTOINCREMENT` for auto‑increment columns.
+- **PostgreSQL** (`PostgresPlatform`) – Adapts `LIMIT`/`OFFSET` clauses and sets the `SERIAL` keyword for auto‑increment fields.
+- **SQL Server** (`SqlServerPlatform`) – Uses the `OFFSET/FETCH` pattern and the `IDENTITY(1,1)` keyword.
+
+Select the appropriate platform when creating a `Crud` instance:
+
+```php
+use DBAL\Platform\PostgresPlatform;
+
+$pdo  = new PDO('pgsql:host=localhost;dbname=demo');
+$crud = new DBAL\Crud($pdo, new PostgresPlatform());
+```
+
+## Adding Support for Other Engines
+
+New engines can be supported by implementing `DBAL\Platform\PlatformInterface` and providing the SQL variations required by that engine. At minimum you must implement:
+
+```php
+interface PlatformInterface
+{
+    public function applyLimitOffset(MessageInterface $message, ?int $limit, ?int $offset): MessageInterface;
+    public function autoIncrementKeyword(): string;
+}
+```
+
+1. **Create your platform class** implementing these methods.
+2. Use the class when constructing `Crud` or `Query` objects.
+
+Example skeleton for MySQL:
+
+```php
+namespace DBAL\Platform;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+class MysqlPlatform implements PlatformInterface
+{
+    public function applyLimitOffset(MessageInterface $msg, ?int $limit, ?int $offset): MessageInterface
+    {
+        if ($limit === null && $offset === null) {
+            return $msg;
+        }
+        $sql = 'LIMIT ';
+        $values = [];
+        if ($limit !== null) {
+            $sql .= '?';
+            $values[] = $limit;
+        }
+        if ($offset !== null) {
+            $sql .= $limit !== null ? ' OFFSET ?' : '?, ?';
+            $values[] = $offset;
+        }
+        return $msg->addValues($values)->insertAfter($sql);
+    }
+
+    public function autoIncrementKeyword(): string
+    {
+        return 'AUTO_INCREMENT';
+    }
+}
+```
+
+Once implemented you can use it in your application:
+
+```php
+$crud = new DBAL\Crud($pdo, new MysqlPlatform());
+```
+
+This design keeps the core library lightweight while allowing developers to adapt it to any SQL dialect supported by PDO.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -30,6 +30,7 @@ DBAL aims to be framework‑agnostic and has no dependencies beyond PDO. It work
 - **`examples.md`** – practical scenarios such as managing a book store, handling cinema tickets or implementing a logistics API.
 - **`lazy-relations.md`** – details the `LazyRelation` helper used for on-demand loading of related rows.
 - **`filters.md`** – extending filters and simplifying queries.
+- **`engines.md`** – supported database platforms and how to create your own.
 
 Each file can be read in isolation, but together they provide a comprehensive guide to DBAL.
 


### PR DESCRIPTION
## Summary
- document built in platforms and how to create new ones in `docs/engines.md`
- mention platform classes in feature list
- add a section in README describing database engines and linking to the new doc
- include the doc in the documentation map

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686857b67890832c8ad7fd9cb9e7a38a