### PR TITLE
Increase test coverage with additional cases

### DIFF
--- a/tests/CacheStorageTest.php
+++ b/tests/CacheStorageTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\MemoryCacheStorage;
+use DBAL\SqliteCacheStorage;
+
+class CacheStorageTest extends TestCase
+{
+    public function testMemoryCacheStorage(): void
+    {
+        $storage = new MemoryCacheStorage();
+        $this->assertNull($storage->get('foo'));
+        $storage->set('foo', 'bar');
+        $this->assertSame('bar', $storage->get('foo'));
+        $storage->delete('foo');
+        $this->assertNull($storage->get('foo'));
+        $storage->set('a', 1);
+        $storage->set('b', 2);
+        $storage->delete();
+        $this->assertNull($storage->get('a'));
+        $this->assertNull($storage->get('b'));
+    }
+
+    public function testSqliteCacheStorage(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'cache');
+        $storage = new SqliteCacheStorage($file);
+        $this->assertNull($storage->get('foo'));
+        $storage->set('foo', 'bar');
+        $this->assertSame('bar', $storage->get('foo'));
+        $storage->delete('foo');
+        $this->assertNull($storage->get('foo'));
+        $storage->set('a', 1);
+        $storage->set('b', 2);
+        $storage->delete();
+        $this->assertNull($storage->get('a'));
+        $this->assertNull($storage->get('b'));
+        unlink($file);
+    }
+}

--- a/tests/DevelopmentErrorMiddlewareTest.php
+++ b/tests/DevelopmentErrorMiddlewareTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\DevelopmentErrorMiddleware;
+use ReflectionClass;
+
+class DevelopmentErrorMiddlewareTest extends TestCase
+{
+    public function testRenderAndPersist(): void
+    {
+        $dir = sys_get_temp_dir() . '/deverr_' . uniqid();
+        $mw = new DevelopmentErrorMiddleware([
+            'console' => false,
+            'persistPath' => $dir,
+            'theme' => 'dark',
+            'fontSize' => 'large',
+        ]);
+        // restore previous exception handler
+        restore_exception_handler();
+
+        $ref = new ReflectionClass($mw);
+        $render = $ref->getMethod('renderHtml');
+        $render->setAccessible(true);
+        $html = $render->invoke($mw, new Exception('boom'));
+        $this->assertStringContainsString('boom', $html);
+
+        $persist = $ref->getMethod('persist');
+        $persist->setAccessible(true);
+        $persist->invoke($mw, $html);
+
+        $dirs = glob($dir . '/*');
+        $this->assertNotEmpty($dirs);
+        $files = scandir($dirs[0]);
+        $this->assertContains('error.html', $files);
+
+        $css = $ref->getMethod('css');
+        $css->setAccessible(true);
+        $this->assertStringContainsString('body', $css->invoke($mw));
+
+        $js = $ref->getMethod('js');
+        $js->setAccessible(true);
+        $this->assertStringContainsString('setTheme', $js->invoke($mw));
+
+        foreach ($dirs as $d) { array_map('unlink', glob($d.'/*')); rmdir($d); }
+        rmdir($dir);
+    }
+}

--- a/tests/NodeOperationsTest.php
+++ b/tests/NodeOperationsTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\QueryBuilder\Node\Node;
+use DBAL\QueryBuilder\Node\EmptyNode;
+use DBAL\QueryBuilder\Message;
+use DBAL\QueryBuilder\MessageInterface;
+
+class DummyNode extends Node
+{
+    protected bool $isEmpty = false;
+    public function send(MessageInterface $message)
+    {
+        return $message->insertAfter('dummy');
+    }
+}
+
+class NodeOperationsTest extends TestCase
+{
+    private function createNode()
+    {
+        return new class extends Node {
+            protected bool $isEmpty = false;
+            public function send(MessageInterface $message) { return $message; }
+        };
+    }
+
+    public function testChildManagement(): void
+    {
+        $parent = $this->createNode();
+        $child  = new DummyNode();
+        $key = $parent->appendChild($child);
+        $this->assertEquals(0, $key);
+        $this->assertTrue($parent->hasChild($key));
+        $this->assertSame($child, $parent->getChild($key));
+
+        $removed = $parent->removeChild($key);
+        $this->assertSame($child, $removed);
+        $this->assertFalse($parent->hasChild($key));
+        $this->assertInstanceOf(EmptyNode::class, $parent->getChild('missing'));
+        $this->assertInstanceOf(EmptyNode::class, $parent->removeChild('missing'));
+    }
+
+    public function testCloneDeepCopiesChildren(): void
+    {
+        $parent = $this->createNode();
+        $child  = new DummyNode();
+        $parent->appendChild($child);
+        $clone = clone $parent;
+        $this->assertNotSame($parent->getChild(0), $clone->getChild(0));
+    }
+}


### PR DESCRIPTION
## Summary
- add CacheStorage tests for memory and sqlite implementations
- test basic node hierarchy features
- verify DevelopmentErrorMiddleware rendering and persistence

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml --coverage-text` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868593eaf3c832c80d6aff1df757413