### PR TITLE
Add Mysql/MariaDB platform support

### DIFF
--- a/DBAL/Platform/MariaDbPlatform.php
+++ b/DBAL/Platform/MariaDbPlatform.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+namespace DBAL\Platform;
+
+/**
+ * MariaDB dialect reusing MysqlPlatform behaviour.
+ */
+class MariaDbPlatform extends MysqlPlatform
+{
+}

--- a/DBAL/Platform/MysqlPlatform.php
+++ b/DBAL/Platform/MysqlPlatform.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+namespace DBAL\Platform;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+/**
+ * MySQL/MariaDB specific SQL dialect implementation.
+ */
+class MysqlPlatform implements PlatformInterface
+{
+    public function applyLimitOffset(MessageInterface $message, ?int $limit, ?int $offset): MessageInterface
+    {
+        if ($limit === null && $offset === null) {
+            return $message;
+        }
+
+        $sql = 'LIMIT ';
+        $values = [];
+        if ($limit !== null) {
+            $sql .= '?';
+            $values[] = $limit;
+        }
+        if ($offset !== null) {
+            $sql .= $limit !== null ? ' OFFSET ?' : '?, ?';
+            $values[] = $offset;
+        }
+        return $message->addValues($values)->insertAfter($sql);
+    }
+
+    public function autoIncrementKeyword(): string
+    {
+        return 'AUTO_INCREMENT';
+    }
+}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A lightweight Database Abstraction Layer for PHP.
 - Lazy and eager loading of relations
 - Middleware system with caching, transactions, validation and more
 - Schema builder and migration helpers
-- Platform classes for SQLite, PostgreSQL and SQL Server
+- Platform classes for SQLite, PostgreSQL, SQL Server and MySQL/MariaDB
 - Attribute based entity validation and relation definition
 - Relation loader middleware for programmatic relations ([docs](docs/middlewares.md#relationloadermiddleware))
 - First/Last and Linq helpers
@@ -45,7 +45,7 @@ SELECT * FROM users;
 
 ## Database Engines
 
-DBAL relies solely on PDO, so it can connect to any engine with a PDO driver. It includes platform classes for SQLite, PostgreSQL and SQL Server. Use the appropriate platform when creating a `Crud` instance:
+DBAL relies solely on PDO, so it can connect to any engine with a PDO driver. It includes platform classes for SQLite, PostgreSQL, SQL Server and MySQL/MariaDB. Use the appropriate platform when creating a `Crud` instance:
 
 ```php
 use DBAL\Platform\PostgresPlatform;

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -7,6 +7,7 @@ DBAL uses PHP's PDO extension as its only dependency. This means it can work wit
 - **SQLite** (`SqlitePlatform`) – Default behaviour when no platform is passed. It understands SQLite's `LIMIT` syntax and uses `AUTOINCREMENT` for auto‑increment columns.
 - **PostgreSQL** (`PostgresPlatform`) – Adapts `LIMIT`/`OFFSET` clauses and sets the `SERIAL` keyword for auto‑increment fields.
 - **SQL Server** (`SqlServerPlatform`) – Uses the `OFFSET/FETCH` pattern and the `IDENTITY(1,1)` keyword.
+- **MySQL/MariaDB** (`MysqlPlatform`, `MariaDbPlatform`) – Share the same dialect, using `LIMIT` and the `AUTO_INCREMENT` keyword.
 
 Select the appropriate platform when creating a `Crud` instance:
 


### PR DESCRIPTION
## Summary
- add MySQL/MariaDB platform implementation classes
- mention new platforms in README and engines docs

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68685a0ed550832cbb4666369b55c26f