### PR TITLE
Add cache adapters and queue event middleware

### DIFF
--- a/DBAL/MemcachedCacheStorage.php
+++ b/DBAL/MemcachedCacheStorage.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+namespace DBAL;
+
+/**
+ * Memcached backed cache storage.
+ */
+class MemcachedCacheStorage implements CacheStorageInterface
+{
+    private \Memcached $memcached;
+    private string $prefix;
+
+    public function __construct(\Memcached $memcached, string $prefix = 'dbal:')
+    {
+        $this->memcached = $memcached;
+        $this->prefix    = $prefix;
+    }
+
+    public function get(string $key)
+    {
+        $val = $this->memcached->get($this->prefix . $key);
+        return $val === false ? null : $val;
+    }
+
+    public function set(string $key, $value): void
+    {
+        $this->memcached->set($this->prefix . $key, $value);
+    }
+
+    public function delete(string $key = null): void
+    {
+        if ($key === null) {
+            $this->memcached->flush();
+        } else {
+            $this->memcached->delete($this->prefix . $key);
+        }
+    }
+}

--- a/DBAL/QueueEventMiddleware.php
+++ b/DBAL/QueueEventMiddleware.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+/**
+ * Middleware that publishes CRUD events to a message queue.
+ */
+class QueueEventMiddleware implements CrudEventInterface
+{
+    private $publisher;
+    private string $topic;
+
+    /**
+     * @param callable $publisher Function accepting topic and payload.
+     * @param string $topic       Destination topic or channel.
+     */
+    public function __construct(callable $publisher, string $topic)
+    {
+        $this->publisher = \Closure::fromCallable($publisher);
+        $this->topic     = $topic;
+    }
+
+    public function __invoke(MessageInterface $msg): void
+    {
+        // no-op
+    }
+
+    public function afterInsert(string $table, array $fields, $id): void
+    {
+        ($this->publisher)($this->topic, [
+            'action' => 'insert',
+            'table'  => $table,
+            'fields' => $fields,
+            'id'     => $id,
+        ]);
+    }
+
+    public function afterBulkInsert(string $table, array $rows, int $count): void
+    {
+        ($this->publisher)($this->topic, [
+            'action' => 'bulkInsert',
+            'table'  => $table,
+            'rows'   => $rows,
+            'count'  => $count,
+        ]);
+    }
+
+    public function afterUpdate(string $table, array $fields, int $count): void
+    {
+        ($this->publisher)($this->topic, [
+            'action' => 'update',
+            'table'  => $table,
+            'fields' => $fields,
+            'count'  => $count,
+        ]);
+    }
+
+    public function afterDelete(string $table, int $count): void
+    {
+        ($this->publisher)($this->topic, [
+            'action' => 'delete',
+            'table'  => $table,
+            'count'  => $count,
+        ]);
+    }
+}

--- a/DBAL/RedisCacheStorage.php
+++ b/DBAL/RedisCacheStorage.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+namespace DBAL;
+
+/**
+ * Redis backed cache storage.
+ *
+ * Keys are automatically prefixed to avoid collisions with other data.
+ */
+class RedisCacheStorage implements CacheStorageInterface
+{
+    private \Redis $redis;
+    private string $prefix;
+
+    public function __construct(\Redis $redis, string $prefix = 'dbal:')
+    {
+        $this->redis = $redis;
+        $this->prefix = $prefix;
+    }
+
+    public function get(string $key)
+    {
+        $val = $this->redis->get($this->prefix . $key);
+        return $val === false ? null : unserialize($val);
+    }
+
+    public function set(string $key, $value): void
+    {
+        $this->redis->set($this->prefix . $key, serialize($value));
+    }
+
+    public function delete(string $key = null): void
+    {
+        if ($key === null) {
+            foreach ($this->redis->keys($this->prefix . '*') as $k) {
+                $this->redis->del($k);
+            }
+        } else {
+            $this->redis->del($this->prefix . $key);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ A lightweight Database Abstraction Layer for PHP.
 ## What's New
 - Requires **PHP 8.1** and uses attributes for entity validation and relations
 - ActiveRecord support with dynamic properties
-- Caching middleware with pluggable storage
+- Caching middleware with pluggable storage (includes Redis and Memcached adapters)
 - Transaction and Unit of Work middlewares
 - CRUD event hooks to listen for inserts, updates or deletes
+- Queue middleware to publish events to systems like Kafka
 - Improved documentation and error pages
 
 
@@ -584,7 +585,7 @@ $crud = (new DBAL\Crud($pdo))
 
 ### Cache middleware
 
-`CacheMiddleware` caches the result of SELECT statements and clears the cache when data changes. It defaults to the in-memory `MemoryCacheStorage`, but you can use the provided `SqliteCacheStorage` or any custom `CacheStorageInterface` implementation.
+`CacheMiddleware` caches the result of SELECT statements and clears the cache when data changes. It defaults to the in-memory `MemoryCacheStorage`, but adapters for `Redis` and `Memcached` are also available alongside the `SqliteCacheStorage`. Any custom `CacheStorageInterface` implementation can be used.
 
 ### Active record
 
@@ -612,6 +613,10 @@ $record->update(); // only changed fields are written
 ### CRUD event middleware
 
 `CrudEventMiddleware` lets you execute callbacks after inserts, bulk inserts, updates or deletes to implement custom hooks.
+
+### Queue event middleware
+
+`QueueEventMiddleware` publishes CRUD events to an external message queue like Kafka. Provide a callable that sends messages and the target topic when constructing the middleware.
 
 ### Query timing middleware
 

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -53,11 +53,19 @@ request. Whenever an insert, update or delete is executed through the attached
 `Crud` instance the cache is flushed to keep results consistent.
 
 If you need persistence across requests you can provide a different storage
-backend. DBAL includes a `SqliteCacheStorage` adapter:
+backend. DBAL includes adapters for SQLite, Redis and Memcached:
 
 ```php
 $cache = new DBAL\CacheMiddleware(
     new DBAL\SqliteCacheStorage(__DIR__ . '/cache.sqlite')
+);
+// or
+$cache = new DBAL\CacheMiddleware(
+    new DBAL\RedisCacheStorage($redis)
+);
+// or
+$cache = new DBAL\CacheMiddleware(
+    new DBAL\MemcachedCacheStorage($memcached)
 );
 $crud = (new DBAL\Crud($pdo))
     ->from('users')
@@ -141,6 +149,9 @@ $crud->commit();
 
 ## CrudEventMiddleware
 Allows executing callbacks after insert, bulk insert, update or delete operations.
+
+## QueueEventMiddleware
+Publishes CRUD events to an external message queue like Kafka. Construct it with a callable publisher and the target topic.
 
 ## FirstLastMiddleware
 Adds `first()`, `firstOrDefault()`, `last()` and `lastOrDefault()` to quickly fetch a single row.

--- a/tests/MemcachedCacheStorageTest.php
+++ b/tests/MemcachedCacheStorageTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\MemcachedCacheStorage;
+
+class FakeMemcached
+{
+    public array $data = [];
+    public function get($key)
+    {
+        return $this->data[$key] ?? false;
+    }
+    public function set($key, $value)
+    {
+        $this->data[$key] = $value;
+    }
+    public function delete($key)
+    {
+        unset($this->data[$key]);
+    }
+    public function flush()
+    {
+        $this->data = [];
+    }
+}
+
+class MemcachedCacheStorageTest extends TestCase
+{
+    public function testBasicOperations()
+    {
+        $mc = new FakeMemcached();
+        $storage = new MemcachedCacheStorage($mc, 'p:');
+
+        $storage->set('k', 1);
+        $this->assertEquals(1, $storage->get('k'));
+
+        $storage->delete('k');
+        $this->assertNull($storage->get('k'));
+
+        $storage->set('a', 'x');
+        $storage->set('b', 'y');
+        $storage->delete();
+        $this->assertNull($storage->get('a'));
+        $this->assertNull($storage->get('b'));
+    }
+}

--- a/tests/QueueEventMiddlewareTest.php
+++ b/tests/QueueEventMiddlewareTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\QueueEventMiddleware;
+
+class QueueEventMiddlewareTest extends TestCase
+{
+    public function testEventsArePublished()
+    {
+        $events = [];
+        $publisher = function (string $topic, array $payload) use (&$events) {
+            $events[] = [$topic, $payload];
+        };
+
+        $mw = new QueueEventMiddleware($publisher, 'events');
+
+        $mw->afterInsert('t', ['f' => 'v'], 1);
+        $mw->afterBulkInsert('t', [['f' => 'v']], 1);
+        $mw->afterUpdate('t', ['f' => 'x'], 2);
+        $mw->afterDelete('t', 3);
+
+        $this->assertCount(4, $events);
+        $this->assertEquals('insert', $events[0][1]['action']);
+        $this->assertEquals('bulkInsert', $events[1][1]['action']);
+        $this->assertEquals('update', $events[2][1]['action']);
+        $this->assertEquals('delete', $events[3][1]['action']);
+    }
+}

--- a/tests/RedisCacheStorageTest.php
+++ b/tests/RedisCacheStorageTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\RedisCacheStorage;
+use DBAL\CacheStorageInterface;
+
+class FakeRedis
+{
+    public array $data = [];
+    public array $calls = [];
+    public function get($key)
+    {
+        $this->calls[] = ['get', $key];
+        return $this->data[$key] ?? false;
+    }
+    public function set($key, $value)
+    {
+        $this->calls[] = ['set', $key, $value];
+        $this->data[$key] = $value;
+    }
+    public function del($key)
+    {
+        $this->calls[] = ['del', $key];
+        unset($this->data[$key]);
+    }
+    public function keys($pattern)
+    {
+        $this->calls[] = ['keys', $pattern];
+        $prefix = rtrim($pattern, '*');
+        return array_values(array_filter(array_keys($this->data), fn($k) => str_starts_with($k, $prefix)));
+    }
+}
+
+class RedisCacheStorageTest extends TestCase
+{
+    public function testBasicOperations()
+    {
+        $redis = new FakeRedis();
+        $storage = new RedisCacheStorage($redis, 'p:');
+
+        $storage->set('k', ['v']);
+        $this->assertEquals(['v'], $storage->get('k'));
+
+        $storage->delete('k');
+        $this->assertNull($storage->get('k'));
+
+        $storage->set('a', 1);
+        $storage->set('b', 2);
+        $storage->delete();
+        $this->assertNull($storage->get('a'));
+        $this->assertNull($storage->get('b'));
+    }
+}


### PR DESCRIPTION
## Summary
- add `RedisCacheStorage` and `MemcachedCacheStorage`
- introduce `QueueEventMiddleware` to publish CRUD events
- document new middlewares and adapters
- tests for new classes

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68685a5d3a6c832c913021e4e65abcba