### PR TITLE
Use query nodes for schema and caching

### DIFF
--- a/DBAL/QueryBuilder/Node/ReplaceNode.php
+++ b/DBAL/QueryBuilder/Node/ReplaceNode.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+namespace DBAL\QueryBuilder\Node;
+
+use DBAL\QueryBuilder\MessageInterface;
+
+/**
+ * Node that converts INSERT INTO statements to REPLACE INTO.
+ */
+class ReplaceNode extends Node
+{
+    protected bool $isEmpty = false;
+
+    public function send(MessageInterface $message)
+    {
+        return $message->replace('INSERT INTO', 'REPLACE INTO');
+    }
+}

--- a/DBAL/Schema/Node/AlterTableNode.php
+++ b/DBAL/Schema/Node/AlterTableNode.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+namespace DBAL\Schema\Node;
+
+use DBAL\QueryBuilder\Node\Node;
+use DBAL\QueryBuilder\MessageInterface;
+use DBAL\QueryBuilder\Message;
+
+/**
+ * Node used to build ALTER TABLE statements.
+ */
+class AlterTableNode extends Node
+{
+    protected bool $isEmpty = false;
+
+    public function __construct(private string $table)
+    {
+    }
+
+    public function send(MessageInterface $message)
+    {
+        $defs = new Message($message->type());
+        foreach ($this->allChildren() as $child) {
+            $defs = $child->send($defs);
+        }
+        $sql = sprintf('ALTER TABLE %s %s', $this->table, $defs->readMessage());
+        return $message->insertAfter($sql);
+    }
+}

--- a/DBAL/Schema/Node/CreateTableNode.php
+++ b/DBAL/Schema/Node/CreateTableNode.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+namespace DBAL\Schema\Node;
+
+use DBAL\QueryBuilder\Node\Node;
+use DBAL\QueryBuilder\MessageInterface;
+use DBAL\QueryBuilder\Message;
+
+/**
+ * Node used to build CREATE TABLE statements.
+ */
+class CreateTableNode extends Node
+{
+    protected bool $isEmpty = false;
+
+    public function __construct(private string $table, private bool $ifNotExists = false)
+    {
+    }
+
+    public function send(MessageInterface $message)
+    {
+        $defs = new Message($message->type());
+        foreach ($this->allChildren() as $child) {
+            $defs = $child->send($defs);
+        }
+        $template = $this->ifNotExists ? 'CREATE TABLE IF NOT EXISTS %s (%s)' : 'CREATE TABLE %s (%s)';
+        $sql = sprintf($template, $this->table, $defs->readMessage());
+        return $message->insertAfter($sql);
+    }
+}

--- a/DBAL/Schema/Node/TableDefinitionNode.php
+++ b/DBAL/Schema/Node/TableDefinitionNode.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+namespace DBAL\Schema\Node;
+
+use DBAL\QueryBuilder\Node\Node;
+use DBAL\QueryBuilder\MessageInterface;
+
+/**
+ * Node representing a single table definition fragment.
+ */
+class TableDefinitionNode extends Node
+{
+    protected bool $isEmpty = false;
+
+    public function __construct(private string $definition)
+    {
+    }
+
+    public function send(MessageInterface $message)
+    {
+        return $message->insertAfter($this->definition, MessageInterface::SEPARATOR_COMMA);
+    }
+}

--- a/DBAL/Schema/SchemaTableBuilder.php
+++ b/DBAL/Schema/SchemaTableBuilder.php
@@ -59,9 +59,13 @@ class SchemaTableBuilder
 
     public function build(): string
     {
-        $cols = array_map(function (SchemaColumnBuilder $col) {
-            return $col->build();
-        }, $this->columns);
-        return sprintf('CREATE TABLE %s (%s)', $this->name, implode(', ', $cols));
+        $create = new \DBAL\Schema\Node\CreateTableNode($this->name);
+        foreach ($this->columns as $col) {
+            $create->appendChild(
+                new \DBAL\Schema\Node\TableDefinitionNode($col->build())
+            );
+        }
+        $msg = $create->send(new \DBAL\QueryBuilder\Message());
+        return $msg->readMessage();
     }
 }

--- a/DBAL/SqlSchemaTableBuilder.php
+++ b/DBAL/SqlSchemaTableBuilder.php
@@ -85,18 +85,14 @@ class SqlSchemaTableBuilder
             return;
         }
         if ($this->create) {
-            $sql = sprintf(
-                'CREATE TABLE IF NOT EXISTS %s (%s)',
-                $this->table,
-                implode(', ', $this->definitions)
-            );
+            $node = new \DBAL\Schema\Node\CreateTableNode($this->table, true);
         } else {
-            $sql = sprintf(
-                'ALTER TABLE %s %s',
-                $this->table,
-                implode(', ', $this->definitions)
-            );
+            $node = new \DBAL\Schema\Node\AlterTableNode($this->table);
         }
-        $this->pdo->exec($sql);
+        foreach ($this->definitions as $def) {
+            $node->appendChild(new \DBAL\Schema\Node\TableDefinitionNode($def));
+        }
+        $msg = $node->send(new \DBAL\QueryBuilder\Message());
+        $this->pdo->exec($msg->readMessage());
     }
 }


### PR DESCRIPTION
## Summary
- add node-based classes for table schema operations
- refactor SchemaTableBuilder and SqlSchemaTableBuilder to use these nodes
- provide ReplaceNode to transform INSERT INTO statements
- rewrite SqliteCacheStorage queries with the query builder and ReplaceNode

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686859e5cb10832cbc0a792315534b5b