### PR TITLE
Add new query filters

### DIFF
--- a/DBAL/QueryBuilder/FilterOp.php
+++ b/DBAL/QueryBuilder/FilterOp.php
@@ -18,4 +18,17 @@ enum FilterOp: string
     case BETWEEN = 'between';
     case EQF = 'eqf';
     case LIKE = 'like';
+    case STARTS_WITH = 'startsWith';
+    case ENDS_WITH = 'endsWith';
+    case CONTAINS = 'contains';
+    case NOT_LIKE = 'notLike';
+    case IS_NULL = 'isNull';
+    case NOT_NULL = 'notNull';
+    case NOT_IN = 'notIn';
+    case NOT_BETWEEN = 'notBetween';
+    case ILIKE = 'iLike';
+    case REGEX = 'regex';
+    case EXISTS = 'exists';
+    case NOT_EXISTS = 'notExists';
+    case BETWEEN_INCLUSIVE = 'betweenInclusive';
 }

--- a/DBAL/QueryBuilder/Node/FilterNode.php
+++ b/DBAL/QueryBuilder/Node/FilterNode.php
@@ -213,3 +213,84 @@ FilterNode::filter(FilterOp::LIKE, function($field, $value, $msg) {
         return $msg->insertAfter(sprintf('%s LIKE ?', $field), MessageInterface::SEPARATOR_OR)
                    ->addValues([$value]);
 });
+
+FilterNode::filter(FilterOp::STARTS_WITH, function ($field, $value, $msg) {
+        return $msg->insertAfter(sprintf('%s LIKE ?', $field), MessageInterface::SEPARATOR_OR)
+                   ->addValues([$value . '%']);
+});
+
+FilterNode::filter(FilterOp::ENDS_WITH, function ($field, $value, $msg) {
+        return $msg->insertAfter(sprintf('%s LIKE ?', $field), MessageInterface::SEPARATOR_OR)
+                   ->addValues(['%' . $value]);
+});
+
+FilterNode::filter(FilterOp::CONTAINS, function ($field, $value, $msg) {
+        return $msg->insertAfter(sprintf('%s LIKE ?', $field), MessageInterface::SEPARATOR_OR)
+                   ->addValues(['%' . $value . '%']);
+});
+
+FilterNode::filter(FilterOp::NOT_LIKE, function ($field, $value, $msg) {
+        return $msg->insertAfter(sprintf('%s NOT LIKE ?', $field), MessageInterface::SEPARATOR_OR)
+                   ->addValues([$value]);
+});
+
+FilterNode::filter(FilterOp::IS_NULL, function ($field, $value, $msg) {
+        return $msg->insertAfter(sprintf('%s IS NULL', $field), MessageInterface::SEPARATOR_OR);
+});
+
+FilterNode::filter(FilterOp::NOT_NULL, function ($field, $value, $msg) {
+        return $msg->insertAfter(sprintf('%s IS NOT NULL', $field), MessageInterface::SEPARATOR_OR);
+});
+
+FilterNode::filter(FilterOp::NOT_IN, function ($field, $values, $msg) {
+        if ($values instanceof MessageInterface) {
+                $values = $values->insertBefore('(', '')->insertAfter(')', '');
+                return $msg
+                        ->insertAfter(sprintf('%s not in', $field))
+                        ->insertAfter($values->readMessage(), MessageInterface::SEPARATOR_SPACE)
+                        ->addValues($values->getValues());
+        }
+        $q = array_fill(0, sizeof((array) $values), '?');
+        return $msg->insertAfter(sprintf('%s not in (%s)', $field, implode(', ', $q)), MessageInterface::SEPARATOR_OR)
+                   ->addValues((array) $values);
+});
+
+FilterNode::filter(FilterOp::NOT_BETWEEN, function ($field, $values, $msg) {
+        return $msg->insertAfter(sprintf('( %s not between ? AND ? )', $field), MessageInterface::SEPARATOR_OR)
+                   ->addValues((array) $values);
+});
+
+FilterNode::filter(FilterOp::ILIKE, function ($field, $value, $msg) {
+        return $msg->insertAfter(sprintf('%s ILIKE ?', $field), MessageInterface::SEPARATOR_OR)
+                   ->addValues([$value]);
+});
+
+FilterNode::filter(FilterOp::REGEX, function ($field, $value, $msg) {
+        return $msg->insertAfter(sprintf('%s REGEXP ?', $field), MessageInterface::SEPARATOR_OR)
+                   ->addValues([$value]);
+});
+
+FilterNode::filter(FilterOp::EXISTS, function ($field, $value, $msg) {
+        if ($value instanceof MessageInterface) {
+                $value = $value->insertBefore('(', '')->insertAfter(')', '');
+                return $msg->insertAfter('EXISTS', MessageInterface::SEPARATOR_OR)
+                           ->insertAfter($value->readMessage(), MessageInterface::SEPARATOR_SPACE)
+                           ->addValues($value->getValues());
+        }
+        return $msg->insertAfter(sprintf('EXISTS (%s)', $value), MessageInterface::SEPARATOR_OR);
+});
+
+FilterNode::filter(FilterOp::NOT_EXISTS, function ($field, $value, $msg) {
+        if ($value instanceof MessageInterface) {
+                $value = $value->insertBefore('(', '')->insertAfter(')', '');
+                return $msg->insertAfter('NOT EXISTS', MessageInterface::SEPARATOR_OR)
+                           ->insertAfter($value->readMessage(), MessageInterface::SEPARATOR_SPACE)
+                           ->addValues($value->getValues());
+        }
+        return $msg->insertAfter(sprintf('NOT EXISTS (%s)', $value), MessageInterface::SEPARATOR_OR);
+});
+
+FilterNode::filter(FilterOp::BETWEEN_INCLUSIVE, function ($field, $values, $msg) {
+        return $msg->insertAfter(sprintf('( %s between ? AND ? )', $field), MessageInterface::SEPARATOR_OR)
+                   ->addValues((array) $values);
+});

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -72,4 +72,21 @@ class QueryBuilderTest extends TestCase
 
         $this->assertEquals($groupSql, $groupBySql);
     }
+
+    public function testNewFilters()
+    {
+        $query = (new Query())
+            ->from('users')
+            ->where([
+                'name__startsWith' => 'Al',
+                'code__notIn' => ['A', 'B'],
+                'deleted_at__isNull' => null,
+            ]);
+        $msg = $query->buildSelect();
+        $this->assertEquals(
+            'SELECT * FROM users WHERE name LIKE ? AND code not in (?, ?) AND deleted_at IS NULL',
+            $msg->readMessage()
+        );
+        $this->assertEquals(['Al%', 'A', 'B'], $msg->getValues());
+    }
 }


### PR DESCRIPTION
## Summary
- extend FilterOp enumeration with more operations
- implement new filter callbacks for startsWith, endsWith, contains and more
- cover new filters in QueryBuilderTest

## Testing
- `vendor/bin/phpunit tests/QueryBuilderTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68685c78bb5c832c95b98b98011741a5