### PR TITLE
Allow cache storages to accept generic objects

### DIFF
--- a/DBAL/MemcachedCacheStorage.php
+++ b/DBAL/MemcachedCacheStorage.php
@@ -7,10 +7,16 @@ namespace DBAL;
  */
 class MemcachedCacheStorage implements CacheStorageInterface
 {
-    private \Memcached $memcached;
+    /**
+     * Generic memcached client instance.
+     *
+     * The object is expected to expose the standard Memcached API
+     * used by this storage (get, set, delete and flush).
+     */
+    private object $memcached;
     private string $prefix;
 
-    public function __construct(\Memcached $memcached, string $prefix = 'dbal:')
+    public function __construct(object $memcached, string $prefix = 'dbal:')
     {
         $this->memcached = $memcached;
         $this->prefix    = $prefix;

--- a/DBAL/RedisCacheStorage.php
+++ b/DBAL/RedisCacheStorage.php
@@ -9,10 +9,16 @@ namespace DBAL;
  */
 class RedisCacheStorage implements CacheStorageInterface
 {
-    private \Redis $redis;
+    /**
+     * Generic Redis client instance.
+     *
+     * The object must implement the subset of the Redis API used by this
+     * storage (get, set, del and keys).
+     */
+    private object $redis;
     private string $prefix;
 
-    public function __construct(\Redis $redis, string $prefix = 'dbal:')
+    public function __construct(object $redis, string $prefix = 'dbal:')
     {
         $this->redis = $redis;
         $this->prefix = $prefix;


### PR DESCRIPTION
## Summary
- loosen constructor types for `MemcachedCacheStorage` and `RedisCacheStorage`
- update property types and docs

## Testing
- `composer run-script test` *(fails: `composer` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686864439458832c834d54351fa118af