### PR TITLE
Remove unused import

### DIFF
--- a/tests/DevelopmentErrorMiddlewareTest.php
+++ b/tests/DevelopmentErrorMiddlewareTest.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use DBAL\DevelopmentErrorMiddleware;
-use ReflectionClass;
 
 class DevelopmentErrorMiddlewareTest extends TestCase
 {


### PR DESCRIPTION
## Summary
- tidy up `tests/DevelopmentErrorMiddlewareTest.php` by removing the unused `ReflectionClass` import

## Testing
- `vendor/bin/phpunit tests/DevelopmentErrorMiddlewareTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686864471a48832c89dd88299e26c3d1