### PR TITLE
Fix expected SQL formatting in QueryBuilder test

### DIFF
--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -97,7 +97,7 @@ class QueryBuilderTest extends TestCase
             ]);
         $msg = $query->buildSelect();
         $this->assertEquals(
-            'SELECT * FROM users WHERE name LIKE ? AND code not in (?, ?) AND deleted_at IS NULL',
+            'SELECT * FROM users WHERE (name LIKE ? AND code not in (?, ?) AND deleted_at IS NULL)',
             $msg->readMessage()
         );
         $this->assertEquals(['Al%', 'A', 'B'], $msg->getValues());


### PR DESCRIPTION
## Summary
- update `testNewFilters` expected output for parentheses

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6868657bf570832cba02d53486247e5d