### PR TITLE
Add practical OData examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -375,3 +375,27 @@ $rec->update();
 ```
 
 Even though these scenarios use SQLite for brevity, the same code works with any relational database supported by PDO.
+
+## Generic query endpoint with OData
+
+When your application only needs to expose data for simple lookups, `ODataMiddleware`
+can power a single endpoint that handles filtering and pagination automatically.
+
+```php
+$router->get('/packages', function () use ($pdo) {
+    $mw   = new DBAL\ODataMiddleware();
+    $crud = $mw->attach((new DBAL\Crud($pdo))->from('packages'));
+
+    return response()->json($mw->query($_SERVER['QUERY_STRING'] ?? ''));
+});
+```
+
+Clients may request:
+
+```
+/packages?$filter=status%20eq%20'delivered'&$select=code,status&$top=20
+```
+
+and receive the matching rows without additional controller logic. A wide range
+of queries can be served through this single route, avoiding a proliferation of
+custom endpoints.

--- a/docs/odata.md
+++ b/docs/odata.md
@@ -47,3 +47,29 @@ foreach ($paged->select(...$fields) as $row) {
 $odata = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
 $rows  = $mw->query($odata);
 ```
+
+### Simplifying API endpoints
+
+You can expose a single route that accepts any combination of OData parameters
+and let the middleware translate them into SQL automatically. This approach keeps
+your API surface small while remaining flexible.
+
+```php
+$mw   = new DBAL\ODataMiddleware();
+$crud = $mw->attach((new DBAL\Crud($pdo))->from('books'));
+
+$query = $_SERVER['QUERY_STRING'] ?? '';
+$rows  = $mw->query($query);
+
+header('Content-Type: application/json');
+echo json_encode($rows);
+```
+
+Requests such as:
+
+```
+/books?$filter=price%20lt%2020&$orderby=title%20asc&$select=title,price&$top=5
+```
+
+return the filtered list of books without additional endpoint logic. OData
+parameters cover most filtering and pagination needs, reducing custom API code.


### PR DESCRIPTION
## Summary
- expand documentation for OData middleware with a section on simplifying API endpoints
- show a new use case in `examples.md` using OData to build a generic route

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686867326550832cbf46b48fc31fa744