### PR TITLE
Add GraphQL middleware support

### DIFF
--- a/DBAL/GraphQLMiddleware.php
+++ b/DBAL/GraphQLMiddleware.php
@@ -1,0 +1,156 @@
+<?php
+declare(strict_types=1);
+namespace DBAL;
+
+use DBAL\QueryBuilder\MessageInterface;
+use DBAL\QueryBuilder\FilterOp;
+use GraphQL\GraphQL;
+use GraphQL\Type\Schema;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Utils\AST;
+use PDO;
+
+/**
+ * Middleware that executes GraphQL queries and mutations on a Crud instance.
+ */
+class GraphQLMiddleware implements MiddlewareInterface, CrudAwareMiddlewareInterface
+{
+    private ?Crud $crud = null;
+    private Schema $schema;
+    private ScalarType $jsonType;
+    private array $columns = [];
+
+    public function __invoke(MessageInterface $msg): void
+    {
+        // no-op
+    }
+
+    /**
+     * Attach the middleware to a Crud instance and build the schema.
+     */
+    public function attach(Crud $crud): Crud
+    {
+        $crud = $crud->withMiddleware($this);
+        $this->crud = $crud;
+
+        $pdo = (function () { return $this->connection; })->call($crud);
+        $tables = (function () { return $this->tables; })->call($crud);
+        $table = $tables[0] ?? null;
+        if ($table !== null) {
+            $this->columns = $this->fetchColumns($pdo, $table);
+        }
+        $this->buildSchema();
+        return $crud;
+    }
+
+    /**
+     * Execute a GraphQL query string and return the result as an array.
+     */
+    public function handle(string $request): array
+    {
+        if (!$this->crud) {
+            throw new \LogicException('GraphQLMiddleware not attached to Crud');
+        }
+        $result = GraphQL::executeQuery($this->schema, $request);
+        return $result->toArray();
+    }
+
+    private function fetchColumns(PDO $pdo, string $table): array
+    {
+        $stm = $pdo->query("SELECT * FROM {$table} LIMIT 0");
+        $cols = [];
+        if ($stm) {
+            $count = $stm->columnCount();
+            for ($i = 0; $i < $count; $i++) {
+                $meta = $stm->getColumnMeta($i);
+                if (isset($meta['name'])) {
+                    $cols[] = $meta['name'];
+                }
+            }
+        }
+        return $cols;
+    }
+
+    private function buildSchema(): void
+    {
+        $this->jsonType = new ScalarType([
+            'name' => 'JSON',
+            'serialize' => fn($v) => $v,
+            'parseValue' => fn($v) => $v,
+            'parseLiteral' => fn($v) => AST::valueFromASTUntyped($v),
+        ]);
+
+        $recordFields = [];
+        foreach ($this->columns as $c) {
+            $recordFields[$c] = ['type' => Type::string()];
+        }
+        $recordType = new ObjectType([
+            'name' => 'Record',
+            'fields' => $recordFields,
+        ]);
+
+        $queryType = new ObjectType([
+            'name' => 'Query',
+            'fields' => [
+                'read' => [
+                    'type' => Type::listOf($recordType),
+                    'args' => [
+                        'filter' => ['type' => $this->jsonType],
+                    ],
+                    'resolve' => function ($root, array $args) {
+                        $c = $this->crud;
+                        if (isset($args['filter'])) {
+                            $c = $c->where($args['filter']);
+                        }
+                        return iterator_to_array($c->select(...$this->columns));
+                    },
+                ],
+            ],
+        ]);
+
+        $mutationType = new ObjectType([
+            'name' => 'Mutation',
+            'fields' => [
+                'insert' => [
+                    'type' => Type::int(),
+                    'args' => [
+                        'data' => ['type' => $this->jsonType],
+                    ],
+                    'resolve' => function ($root, array $args) {
+                        return (int)$this->crud->insert((array)$args['data']);
+                    },
+                ],
+                'update' => [
+                    'type' => Type::int(),
+                    'args' => [
+                        'id' => Type::nonNull(Type::int()),
+                        'data' => ['type' => $this->jsonType],
+                    ],
+                    'resolve' => function ($root, array $args) {
+                        return $this->crud
+                            ->where(['id' => [FilterOp::EQ, $args['id']]])
+                            ->update((array)$args['data']);
+                    },
+                ],
+                'delete' => [
+                    'type' => Type::int(),
+                    'args' => [
+                        'id' => Type::nonNull(Type::int()),
+                    ],
+                    'resolve' => function ($root, array $args) {
+                        return $this->crud
+                            ->where(['id' => [FilterOp::EQ, $args['id']]])
+                            ->delete();
+                    },
+                ],
+            ],
+        ]);
+
+        $this->schema = new Schema([
+            'query' => $queryType,
+            'mutation' => $mutationType,
+        ]);
+    }
+}

--- a/DBAL/Hooks/helpers.php
+++ b/DBAL/Hooks/helpers.php
@@ -16,6 +16,7 @@ use DBAL\SchemaMiddleware;
 use DBAL\EntityValidationMiddleware;
 use DBAL\AbmEventMiddleware;
 use DBAL\ODataMiddleware;
+use DBAL\GraphQLMiddleware;
 
 /**
  * Create a Crud instance bound to a table.
@@ -162,5 +163,17 @@ function useOData(Crud $crud): array
 {
     $mw = new ODataMiddleware();
     $crud = $crud->withMiddleware($mw);
+    return [$crud, $mw];
+}
+
+/**
+ * Attach the GraphQL middleware and return it.
+ *
+ * @return array{Crud, GraphQLMiddleware}
+ */
+function useGraphQL(Crud $crud): array
+{
+    $mw = new GraphQLMiddleware();
+    $crud = $mw->attach($crud);
     return [$crud, $mw];
 }

--- a/README.md
+++ b/README.md
@@ -548,6 +548,17 @@ $books = $mw->query($odata);
 //     ...
 // ]
 ```
+
+### GraphQL middleware
+
+`GraphQLMiddleware` executes GraphQL queries and mutations using a `Crud` instance. It exposes a `read` query and `insert`, `update` and `delete` mutations. See [`docs/graphql.md`](docs/graphql.md) for more information.
+
+```php
+$mw   = new DBAL\GraphQLMiddleware();
+$crud = $mw->attach((new DBAL\Crud($pdo))->from('books'));
+
+$result = $mw->handle('{ read { id, title } }');
+```
 ### Schema middleware
 
 `SchemaMiddleware` provides a fluent API to create or modify tables via the `Crud` instance.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     },
     "require": {
         "php": ">=8.1",
-        "psr/log": "^1"
+        "psr/log": "^1",
+        "webonyx/graphql-php": "^15"
     },
     "require-dev": {
         "phpunit/phpunit": "^9"

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -1,0 +1,22 @@
+# GraphQL Middleware
+
+`GraphQLMiddleware` executes GraphQL queries and mutations using a `Crud` instance. The middleware builds a simple schema for the primary table exposing a `read` query and `insert`, `update` and `delete` mutations.
+
+## Usage
+
+```php
+$mw   = new DBAL\GraphQLMiddleware();
+$crud = $mw->attach((new DBAL\Crud($pdo))->from('books'));
+
+$result = $mw->handle('{ read { id, title } }');
+```
+
+Filters and record data are passed as associative arrays using the `JSON` scalar type. Dynamic filter operators from [`docs/filters.md`](filters.md) are supported.
+
+```php
+$mw->handle('mutation { insert(data: {title: "New"}) }');
+$mw->handle('mutation { update(id: 1, data: {title: "Updated"}) }');
+$mw->handle('mutation { delete(id: 1) }');
+```
+
+The `handle()` method returns the execution result as an array compatible with `GraphQL\GraphQL::executeQuery()`.

--- a/tests/GraphQLMiddlewareTest.php
+++ b/tests/GraphQLMiddlewareTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use DBAL\Crud;
+use DBAL\GraphQLMiddleware;
+
+class GraphQLMiddlewareTest extends TestCase
+{
+    private function createPdo()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        return $pdo;
+    }
+
+    public function testReadInsertUpdateDelete()
+    {
+        $pdo = $this->createPdo();
+        $crud = (new Crud($pdo))->from('items');
+        $mw = new GraphQLMiddleware();
+        $crud = $mw->attach($crud);
+
+        $mw->handle('mutation { insert(data: {name: "A"}) }');
+        $mw->handle('mutation { insert(data: {name: "B"}) }');
+
+        $rows = $mw->handle('{ read { name } }');
+        $this->assertCount(2, $rows['data']['read']);
+
+        $mw->handle('mutation { update(id: 1, data: {name: "C"}) }');
+        $row = $mw->handle('{ read(filter: {id__eq: 1}) { name } }');
+        $this->assertEquals('C', $row['data']['read'][0]['name']);
+
+        $mw->handle('mutation { delete(id: 1) }');
+        $rows = $mw->handle('{ read { id } }');
+        $this->assertCount(1, $rows['data']['read']);
+    }
+}


### PR DESCRIPTION
## Summary
- add `webonyx/graphql-php` dependency
- implement `GraphQLMiddleware` with CRUD resolvers
- expose middleware with `useGraphQL` helper
- document GraphQL middleware usage
- mention GraphQL in README
- add PHPUnit tests for GraphQL middleware

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6868684d61a0832c8ccc55a089bff269