### PR TITLE
Sanitize identifiers and use JSON cache

### DIFF
--- a/DBAL/QueryBuilder/Node/FilterNode.php
+++ b/DBAL/QueryBuilder/Node/FilterNode.php
@@ -153,6 +153,21 @@ class FilterNode extends Node
                 }
                 throw new \RuntimeException(sprintf('The filter "%s" is not exists', $op), 500);
         }
+
+        /**
+         * Validate and quote an SQL identifier (optionally schema-qualified).
+         */
+        private static function quoteIdentifier(string $id): string
+        {
+                $parts = explode('.', $id);
+                foreach ($parts as $i => $p) {
+                        if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $p)) {
+                                throw new \InvalidArgumentException("Invalid identifier: {$id}");
+                        }
+                        $parts[$i] = '"' . $p . '"';
+                }
+                return implode('.', $parts);
+        }
 }
 
 
@@ -206,6 +221,8 @@ FilterNode::filter(FilterOp::BETWEEN, function($field, $values, $message)
 
 FilterNode::filter(FilterOp::EQF, function($field, $value, $message)
 {
+        $field = FilterNode::quoteIdentifier($field);
+        $value = FilterNode::quoteIdentifier((string) $value);
         return $message->insertAfter(sprintf('%s = %s', $field, $value), MessageInterface::SEPARATOR_AND);
 });
 

--- a/DBAL/RedisCacheStorage.php
+++ b/DBAL/RedisCacheStorage.php
@@ -27,12 +27,12 @@ class RedisCacheStorage implements CacheStorageInterface
     public function get(string $key)
     {
         $val = $this->redis->get($this->prefix . $key);
-        return $val === false ? null : unserialize($val);
+        return $val === false ? null : json_decode($val, true);
     }
 
     public function set(string $key, $value): void
     {
-        $this->redis->set($this->prefix . $key, serialize($value));
+        $this->redis->set($this->prefix . $key, json_encode($value));
     }
 
     public function delete(string $key = null): void

--- a/DBAL/SqliteCacheStorage.php
+++ b/DBAL/SqliteCacheStorage.php
@@ -38,7 +38,7 @@ class SqliteCacheStorage implements CacheStorageInterface
         $stmt = $this->pdo->prepare($msg->readMessage());
         $stmt->execute($msg->getValues());
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
-        return $row ? unserialize($row['value']) : null;
+        return $row ? json_decode($row['value'], true) : null;
     }
 
 /**
@@ -50,7 +50,7 @@ class SqliteCacheStorage implements CacheStorageInterface
 
     public function set(string $key, $value): void
     {
-        $msg = $this->query->buildInsert(['key' => $key, 'value' => serialize($value)]);
+        $msg = $this->query->buildInsert(['key' => $key, 'value' => json_encode($value)]);
         $msg = (new \DBAL\QueryBuilder\Node\ReplaceNode())->send($msg);
         $stmt = $this->pdo->prepare($msg->readMessage());
         $stmt->execute($msg->getValues());

--- a/tests/SqlInjectionTest.php
+++ b/tests/SqlInjectionTest.php
@@ -52,8 +52,9 @@ class SqlInjectionTest extends TestCase
         $crud = $mw->attach((new Crud($pdo))->from('items'));
         try {
             $mw->query("\$filter=id eqf '1; DROP TABLE items; --'");
-        } catch (\Throwable $e) {
-            // Ignore driver errors while testing for SQL injection
+            $this->fail('Exception not thrown');
+        } catch (InvalidArgumentException $e) {
+            // Expected
         }
         $count = (int)$pdo->query('SELECT COUNT(*) FROM items')->fetchColumn();
         $this->assertEquals(1, $count);


### PR DESCRIPTION
## Summary
- validate SQL identifiers in `FilterNode` and `SqlSchemaTableBuilder`
- secure `eqf` filter by quoting identifiers
- store cache data with JSON instead of PHP serialization
- adjust injection test to expect an exception

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686868d252a0832c8166729d90604523