### PR TITLE
Update quoteIdentifier visibility

### DIFF
--- a/DBAL/QueryBuilder/Node/FilterNode.php
+++ b/DBAL/QueryBuilder/Node/FilterNode.php
@@ -157,7 +157,7 @@ class FilterNode extends Node
         /**
          * Validate and quote an SQL identifier (optionally schema-qualified).
          */
-        private static function quoteIdentifier(string $id): string
+       public static function quoteIdentifier(string $id): string
         {
                 $parts = explode('.', $id);
                 foreach ($parts as $i => $p) {


### PR DESCRIPTION
## Summary
- expose `quoteIdentifier` to be reusable outside `FilterNode`

## Testing
- `composer run-script test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868e9e6bc68832caba72f8e4e9fce1f