### PR TITLE
Fix unquoted column definitions

### DIFF
--- a/DBAL/SqlSchemaTableBuilder.php
+++ b/DBAL/SqlSchemaTableBuilder.php
@@ -45,7 +45,11 @@ class SqlSchemaTableBuilder
     {
         if ($this->create) {
             if ($type === null) {
-                $this->definitions[] = $this->quoteIdentifier($name);
+                if (str_contains($name, ' ')) {
+                    $this->definitions[] = $name;
+                } else {
+                    $this->definitions[] = $this->quoteIdentifier($name);
+                }
             } else {
                 $this->definitions[] = sprintf('%s %s', $this->quoteIdentifier($name), $type);
             }
@@ -64,7 +68,11 @@ class SqlSchemaTableBuilder
     {
         if (!$this->create) {
             if ($type === null) {
-                $this->definitions[] = sprintf('ADD COLUMN %s', $this->quoteIdentifier($name));
+                if (str_contains($name, ' ')) {
+                    $this->definitions[] = sprintf('ADD COLUMN %s', $name);
+                } else {
+                    $this->definitions[] = sprintf('ADD COLUMN %s', $this->quoteIdentifier($name));
+                }
             } else {
                 $this->definitions[] = sprintf('ADD COLUMN %s %s', $this->quoteIdentifier($name), $type);
             }


### PR DESCRIPTION
## Summary
- allow raw SQL snippets when the column name contains spaces
- handle the same logic when altering tables

## Testing
- `composer run-script test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e9e942e0832cb5a1dbaa655db846