### PR TITLE
Update tests for quoted identifiers

### DIFF
--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -66,7 +66,10 @@ class QueryBuilderTest extends TestCase
                 $j->condition('u.id', \DBAL\QueryBuilder\FilterOp::EQF, 'p.user_id');
             });
         $msg = $query->buildSelect();
-        $this->assertEquals('SELECT * FROM users u LEFT JOIN profiles p ON u.id = p.user_id', $msg->readMessage());
+        $this->assertEquals(
+            'SELECT * FROM users u LEFT JOIN profiles p ON "u"."id" = "p"."user_id"',
+            $msg->readMessage()
+        );
     }
 
     public function testGroupByAlias()

--- a/tests/SubqueryCaseWhenTest.php
+++ b/tests/SubqueryCaseWhenTest.php
@@ -58,7 +58,7 @@ class SubqueryCaseWhenTest extends TestCase
             ->buildSelect($subField);
 
         $this->assertEquals(
-            'SELECT (SELECT COUNT(*) FROM posts WHERE posts.user_id = u.id) cnt FROM users u',
+            'SELECT (SELECT COUNT(*) FROM posts WHERE "posts"."user_id" = "u"."id") cnt FROM users u',
             $msg->readMessage()
         );
     }


### PR DESCRIPTION
## Summary
- fix expectations for quoted identifiers in query builder tests

## Testing
- `vendor/bin/phpunit` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6868f0750950832cab8f61744108a517